### PR TITLE
Change {exitNow} to exit but continue current dialog

### DIFF
--- a/exit-from-dialog.js
+++ b/exit-from-dialog.js
@@ -11,7 +11,7 @@
 
   Using the {exit} function in any part of a series of dialog will make the
   game exit to the new room after the dialog is finished. Using {exitNow} will
-  cut off the dialog text and immediately warp to the new room.
+  immediately warp to the new room, but the current dialog will continue.
 
   WARNING: In exit coordinates, the TOP LEFT tile is (0,0). In sprite coordinates,
            the BOTTOM LEFT tile is (0,0). If you'd like to use sprite coordinates,
@@ -37,7 +37,7 @@
         For full editor integration, you'd *probably* also need to paste this
         code at the end of the editor's `bitsy.js` file. Untested.
 
-  Version: 2.0
+  Version: 2.1
   Bitsy Version: 4.5, 4.6
   License: WTFPL (do WTF you want) except the `_inject` function by @seleb
 */
@@ -76,12 +76,13 @@
   // Implement the {exitNow} dialog function. It exits to the destination room
   // and X/Y coordinates right damn now.
   globals.exitNowFunc = function(environment, parameters, onReturn) {
-    queuedDialogExit = _getExitParams('exitNow', parameters);
-    if (!queuedDialogExit) {
+    var exitParams = _getExitParams('exitNow', parameters);
+    if (!exitParams) {
       return;
     }
 
-    onExitDialog.call(this, environment, parameters, function(){});
+    doPlayerExit(exitParams);
+    onReturn(null);
   }
 
   // Rewrite the Bitsy script tag, making these new functions callable from dialog.


### PR DESCRIPTION
Changes `{exitNow}` so that the room exit happens when the function is encountered, but it doesn't terminate the dialog immediately. Dialog will continue until it finishes naturally.

Note: Using `{exitNow}` at the very beginning of a new page of text will trigger the exit at the end of the previous page. I think Bitsy does some pre-processing of the next page of dialog. You can just move the `{exitNow}` after the first character or first word or whatever to make it trigger during the page it appears in.

![deleteme-bitsy-exitnow](https://user-images.githubusercontent.com/103495/36408690-0127a0b2-15d5-11e8-8c80-f10bd32eb140.gif)
