### PR TITLE
Convert custom function syntax from curly braces to parentheses

### DIFF
--- a/end-from-dialog.js
+++ b/end-from-dialog.js
@@ -5,38 +5,39 @@
 
   Lets you end the game from dialog (including inside conditionals).
 
-  Using the {end} function in any part of a series of dialog will make the
+  Using the (end) function in any part of a series of dialog will make the
   game end after the dialog is finished. Ending the game resets it back to the
   intro.
 
-  Using {endNow} at the end of a sentence will display the whole sentence and
+  Using (endNow) at the end of a sentence will display the whole sentence and
   immediately clear the background. No further dialog from that passage will
-  display, and the game will reset when you proceed. Using {endNow} with
+  display, and the game will reset when you proceed. Using (endNow) with
   narration text will immediately exit the dialog, clear the background, and
   show the ending narration in an ending-style centered dialog box.
 
-  Usage: {end}
-         {end "<ending narration>"}
-         {endNow}
-         {endNow "<ending narration>"}
+  Usage: (end)
+         (end "<ending narration>")
+         (endNow)
+         (endNow "<ending narration>")
 
-  Example: {end}
-           {end "Five friars bid you goodbye. You leave the temple, hopeful."}
-           {endNow "The computer is still online! The chamber floods with neurotoxin."}
+  Example: (end)
+           (end "Five friars bid you goodbye. You leave the temple, hopeful.")
+           (endNow "The computer is still online! The chamber floods with neurotoxin.")
 
   HOW TO USE:
     1. Copy-paste this script into a new script tag after the Bitsy source code.
+       It should appear *before* any other mods that handle loading your game
+       data so it executes *after* them (last-in first-out).
 
-  NOTE: DON'T EDIT DIALOG FOR SPRITES/ITEMS WITH {end} CALLS IN THE DIALOG WINDOW.
-        Always edit them in the dialog textbox of the sprite/item paint window.
-        Editing any part of a sprite or item's dialog in the dialog window will
-        cause the editor replace that sprite/item's `{end}` with `{}` and you
-        probably won't notice that your endings are busted.
+  NOTE: This uses parentheses "()" instead of curly braces "{}" around function
+        calls because the Bitsy editor's fancy dialog window strips unrecognized
+        curly-brace functions from dialog text. To keep from losing data, write
+        these function calls with parentheses like the examples above.
 
         For full editor integration, you'd *probably* also need to paste this
         code at the end of the editor's `bitsy.js` file. Untested.
 
-  Version: 1.0
+  Version: 1.1
   Bitsy Version: 4.5, 4.6
   License: WTFPL (do WTF you want) except the `_inject` function by @seleb
 */
@@ -46,6 +47,17 @@
   'use strict';
 
   var queuedEndingNarration = null;
+
+  // Hook into game load and rewrite custom functions in game data to Bitsy format.
+  var _load_game = load_game;
+  globals.load_game = function(game_data, startWithTitle) {
+     // Rewrite custom functions' parentheses to curly braces for Bitsy's
+     // interpreter. Unescape escaped parentheticals, too.
+    var fixedGameData = game_data
+      .replace(/(^|[^\\])\(((end|endNow)( ".+?")?)\)/g, "$1{$2}") // Rewrite (end...) to {end...}
+      .replace(/(^|\\)\(((end|endNow)( ".+?")?)\\?\)/g, "($2)");   // Rewrite \(end...\) to (end...)
+    _load_game.call(this, fixedGameData, startWithTitle);
+  };
 
   // Hook into the game reset and make sure queued ending data gets cleared.
   var _clearGameData = clearGameData;
@@ -133,3 +145,4 @@
   };
 
 })(window);
+// End of (end) dialog function mod

--- a/exit-from-dialog.js
+++ b/exit-from-dialog.js
@@ -9,35 +9,36 @@
   lets you in once you're disguised, use it to require payment before the
   ferryman will take you across the river.
 
-  Using the {exit} function in any part of a series of dialog will make the
-  game exit to the new room after the dialog is finished. Using {exitNow} will
+  Using the (exit) function in any part of a series of dialog will make the
+  game exit to the new room after the dialog is finished. Using (exitNow) will
   immediately warp to the new room, but the current dialog will continue.
 
   WARNING: In exit coordinates, the TOP LEFT tile is (0,0). In sprite coordinates,
            the BOTTOM LEFT tile is (0,0). If you'd like to use sprite coordinates,
            add the word "sprite" as the fourth parameter to the exit function.
 
-  Usage: {exit "<room name>,<x>,<y>"}
-         {exit "<room name>,<x>,<y>,sprite"}
-         {exitNow "<room name>,<x>,<y>"}
-         {exitNow "<room name>,<x>,<y>,sprite"}
+  Usage: (exit "<room name>,<x>,<y>")
+         (exit "<room name>,<x>,<y>,sprite")
+         (exitNow "<room name>,<x>,<y>")
+         (exitNow "<room name>,<x>,<y>,sprite")
 
-  Example: {exit "FinalRoom,8,4"}
-           {exitNow "FinalRoom,8,11,sprite"}
+  Example: (exit "FinalRoom,8,4")
+           (exitNow "FinalRoom,8,11,sprite")
 
   HOW TO USE:
     1. Copy-paste this script into a new script tag after the Bitsy source code.
+       It should appear *before* any other mods that handle loading your game
+       data so it executes *after* them (last-in first-out).
 
-  NOTE: DON'T EDIT DIALOG FOR SPRITES/ITEMS WITH {exit} CALLS IN THE DIALOG WINDOW.
-        Always edit them in the dialog textbox of the sprite/item paint window.
-        Editing any part of a sprite or item's dialog in the dialog window will
-        cause the editor replace that sprite/item's `{exit "room,5,6"}` with `{}`
-        and you probably won't notice that your exits are busted.
+  NOTE: This uses parentheses "()" instead of curly braces "{}" around function
+        calls because the Bitsy editor's fancy dialog window strips unrecognized
+        curly-brace functions from dialog text. To keep from losing data, write
+        these function calls with parentheses like the examples above.
 
         For full editor integration, you'd *probably* also need to paste this
         code at the end of the editor's `bitsy.js` file. Untested.
 
-  Version: 2.1
+  Version: 2.2
   Bitsy Version: 4.5, 4.6
   License: WTFPL (do WTF you want) except the `_inject` function by @seleb
 */
@@ -47,6 +48,18 @@
   'use strict';
 
   var queuedDialogExit = null;
+
+  // Hook into game load and rewrite custom functions in game data to Bitsy format.
+  var _load_game = load_game;
+  globals.load_game = function(game_data, startWithTitle) {
+     // Rewrite custom functions' parentheses to curly braces for Bitsy's
+     // interpreter. Unescape escaped parentheticals, too. Use regexper.com to
+     // visualize these regexes.
+    var fixedGameData = game_data
+      .replace(/(^|[^\\])\((exit(Now)? ".+?")\)/g, "$1{$2}") // Rewrite (exit...) to {exit...}
+      .replace(/\\\((exit(Now)? ".+")\\?\)/g, "($1)");       // Rewrite \(exit...\) to (exit...)
+    _load_game.call(this, fixedGameData, startWithTitle);
+  };
 
   // Hook into the game reset and make sure exit data gets cleared.
   var _clearGameData = clearGameData;
@@ -174,3 +187,4 @@
   };
 
 })(window);
+// End of (exit) dialog function mod

--- a/external-game-data.js
+++ b/external-game-data.js
@@ -14,6 +14,8 @@
 
   HOW TO USE:
     1. Copy-paste this script into a new script tag after the Bitsy source code.
+       Make sure this script comes *after* any other mods to guarantee that it
+       executes first.
     2. Copy all your Bitsy game data out of the script tag at the top of your
        HTML into another file (I recommend `game-name.bitsydata`). In the HTML
        file, replace all game data with a single IMPORT statement that refers to

--- a/external-game-data.js
+++ b/external-game-data.js
@@ -43,8 +43,15 @@
 (function(globals) {
   'use strict';
 
+  var isFirstLoad = true;
+
   var _load_game = load_game;
   globals.load_game = function(game_data, startWithTitle) {
+    // Bitsy caches the game data on first load & recycles it on soft restarts.
+    if (game_data && !isFirstLoad) {
+      return _load_game.apply(this, arguments);
+    }
+
     tryImportGameData(game_data, function withGameData(err, importedData) {
       if (err) {
         console.warn('Make sure game data IMPORT statement refers to a valid file or URL.');
@@ -52,6 +59,8 @@
       } else {
         _load_game(dos2unix(importedData), startWithTitle);
       }
+
+      isFirstLoad = false;
     });
   };
 


### PR DESCRIPTION
## What do?

Here are some changes to make the `{exit}` and `{end}` mods use `(exit)` and `(end)` parenthetical syntax instead.

## Advantages
- *Compatible with the Bitsy dialog editor window!!* No more losing your function calls because you touched any part of a sprite's conversation in the dialog window.
- Backwards-compatible; internally, it's converting the parentheses to curly braces, so any curly-brace function calls already in your game data will continue to work.
- You'll be able to use the dialog window's preview function, though your function calls will show up in the dialog.

## Disadvantages
- Still doesn't patch the editor, so custom functions still won't work in the editor's "play" mode.
- Custom function code will appear in dialog preview.
- You have to remember a different syntax for invoking these custom functions.
- If you want `(exit "")` or `(end)` in your printed dialog anywhere, you'll need to escape them; use `\(exit "..."\)` and `\(end\)`.
- You have to make sure these custom function mods are registered *above* any game data loader mods in the source code so the loader(s) can run *first*.

## Discussion
Maybe let this PR cook a li'l until I get a bit of feedback on these changes in Discord.