### PR TITLE
External data mod: load data earlier

### DIFF
--- a/external-game-data.js
+++ b/external-game-data.js
@@ -45,8 +45,7 @@
 
   var ERR_MISSING_IMPORT = 1;
 
-  var _startExportedGame = startExportedGame;
-  globals.startExportedGame = function() {
+  hook('startExportedGame', function beforeStart(superFn, superArgs) {
     var gameDataElem = document.scripts.namedItem('exportedGameData');
 
     tryImportGameData(gameDataElem.text, function withGameData(err, importedData) {
@@ -58,9 +57,9 @@
       }
 
       gameDataElem.text = "\n" + dos2unix(importedData);
-      _startExportedGame.apply(this, arguments);
+      superFn.apply(null, superArgs);
     });
-  };
+  });
 
   function tryImportGameData(gameData, done) {
     // Make sure this game data even uses the word "IMPORT".
@@ -113,6 +112,15 @@
     };
 
     request.send();
+  }
+
+  function hook(nameToHook, wrapperFn) {
+    var superFn = globals[nameToHook].bind(globals);
+
+    globals[nameToHook] = function() {
+      var superArgs = [].slice.call(arguments);
+      wrapperFn.apply(this, [superFn, superArgs]);
+    };
   }
 
   function dos2unix(text) {

--- a/external-game-data.js
+++ b/external-game-data.js
@@ -34,7 +34,7 @@
         IMPORTed data. It will not execute nested IMPORT statements in
         external files.
 
-  Version: 1.0
+  Version: 1.1
   Bitsy Version: 4.5, 4.6
   License: WTFPL (do WTF you want)
 */
@@ -43,31 +43,32 @@
 (function(globals) {
   'use strict';
 
-  var isFirstLoad = true;
+  var ERR_MISSING_IMPORT = 1;
 
-  var _load_game = load_game;
-  globals.load_game = function(game_data, startWithTitle) {
-    // Bitsy caches the game data on first load & recycles it on soft restarts.
-    if (game_data && !isFirstLoad) {
-      return _load_game.apply(this, arguments);
-    }
+  var _startExportedGame = startExportedGame;
+  globals.startExportedGame = function() {
+    var gameDataElem = document.scripts.namedItem('exportedGameData');
 
-    tryImportGameData(game_data, function withGameData(err, importedData) {
-      if (err) {
+    tryImportGameData(gameDataElem.text, function withGameData(err, importedData) {
+      if (err && err.error === ERR_MISSING_IMPORT) {
+        console.warn(err.message);
+      } else if (err) {
         console.warn('Make sure game data IMPORT statement refers to a valid file or URL.');
         throw err;
-      } else {
-        _load_game(dos2unix(importedData), startWithTitle);
       }
 
-      isFirstLoad = false;
+      gameDataElem.text = "\n" + dos2unix(importedData);
+      _startExportedGame.apply(this, arguments);
     });
   };
 
   function tryImportGameData(gameData, done) {
-    // Make sure this game data even uses an IMPORT statement.
+    // Make sure this game data even uses the word "IMPORT".
     if (gameData.indexOf('IMPORT') === -1) {
-      return done('No IMPORT found in Bitsy data. See instructions for external game data mod.', gameData);
+      return done(null, {
+        error: ERR_MISSING_IMPORT,
+        message: 'No IMPORT found in Bitsy data. See instructions for external game data mod.'
+      }, gameData);
     }
 
     var trim = function(line) { return line.trim(); };
@@ -76,6 +77,15 @@
       .split("\n")
       .map(trim)
       .find(isImport);
+
+    // Make sure we found an actual IMPORT command.
+    if (!importCmd) {
+      return done({
+        error: ERR_MISSING_IMPORT,
+        message: 'No IMPORT found in Bitsy data. See instructions for external game data mod.'
+      });
+    }
+
     var src = (importCmd || '').split(/\s+/)[1];
 
     if (src) {


### PR DESCRIPTION
This changes the external data mod to run as early as possible, before `startExportedGame()`. It now rewrites the `#exportedGameData` script tag and lets the framework load its data from there as usual. This should let it execute ahead of other mods that may preprocess data during `load_game()`.

I also refactored the way the mod hooks global functions, making the hook a little less noisy and more expressive.