### PR TITLE
Bugfix/escaped dialog commands

### DIFF
--- a/dist/bitsymuse.js
+++ b/dist/bitsymuse.js
@@ -3,7 +3,7 @@
 @file bitsymuse
 @summary A variety of Bitsy sound and music handlers
 @license MIT
-@version 2.1.1
+@version 2.1.2
 @requires 4.8, 4.9
 @author David Mowatt
 
@@ -120,7 +120,7 @@ function unique(array) {
 @file kitsy-script-toolkit
 @summary makes it easier and cleaner to run code before and after Bitsy functions or to inject new code into Bitsy script tags
 @license WTFPL (do WTF you want)
-@version 3.2.1
+@version 3.2.2
 @requires Bitsy Version: 4.5, 4.6
 @author @mildmojo
 
@@ -243,7 +243,8 @@ function applyHook(functionName) {
 				functions[i++].apply(this, args.concat(runBefore.bind(this)));
 			} else {
 				// run synchronously
-				var newArgs = functions[i++].apply(this, args) || args;
+				var newArgs = functions[i++].apply(this, args);
+				newArgs = newArgs && newArgs.length ? newArgs : args;
 				runBefore.apply(this, newArgs);
 			}
 		}
@@ -282,8 +283,8 @@ function addDialogFunction(tag, fn) {
 	}
 
 	// Hook into game load and rewrite custom functions in game data to Bitsy format.
-	before('load_game', function (game_data, startWithTitle) {
-		return [convertDialogTags(game_data, tag), startWithTitle];
+	before('parseWorld', function (game_data) {
+		return [convertDialogTags(game_data, tag)];
 	});
 
 	kitsy.dialogFunctions[tag] = fn;

--- a/dist/canvas replacement.js
+++ b/dist/canvas replacement.js
@@ -3,7 +3,7 @@
 @file canvas replacement
 @summary WebGLazy bitsy integration (this one's mostly just for me)
 @license MIT
-@version 1.1.1
+@version 1.1.2
 @author Sean S. LeBlanc
 
 @description
@@ -113,7 +113,7 @@ function unique(array) {
 @file kitsy-script-toolkit
 @summary makes it easier and cleaner to run code before and after Bitsy functions or to inject new code into Bitsy script tags
 @license WTFPL (do WTF you want)
-@version 3.2.1
+@version 3.2.2
 @requires Bitsy Version: 4.5, 4.6
 @author @mildmojo
 
@@ -217,7 +217,8 @@ function applyHook(functionName) {
 				functions[i++].apply(this, args.concat(runBefore.bind(this)));
 			} else {
 				// run synchronously
-				var newArgs = functions[i++].apply(this, args) || args;
+				var newArgs = functions[i++].apply(this, args);
+				newArgs = newArgs && newArgs.length ? newArgs : args;
 				runBefore.apply(this, newArgs);
 			}
 		}

--- a/dist/custom text effect.js
+++ b/dist/custom text effect.js
@@ -3,7 +3,7 @@
 @file custom text effect
 @summary make {custom}text effects{custom}
 @license MIT
-@version 1.0.2
+@version 1.0.3
 @author Sean S. LeBlanc
 
 @description
@@ -181,7 +181,7 @@ function unique(array) {
 @file kitsy-script-toolkit
 @summary makes it easier and cleaner to run code before and after Bitsy functions or to inject new code into Bitsy script tags
 @license WTFPL (do WTF you want)
-@version 3.2.1
+@version 3.2.2
 @requires Bitsy Version: 4.5, 4.6
 @author @mildmojo
 
@@ -288,7 +288,8 @@ function applyHook(functionName) {
 				functions[i++].apply(this, args.concat(runBefore.bind(this)));
 			} else {
 				// run synchronously
-				var newArgs = functions[i++].apply(this, args) || args;
+				var newArgs = functions[i++].apply(this, args);
+				newArgs = newArgs && newArgs.length ? newArgs : args;
 				runBefore.apply(this, newArgs);
 			}
 		}

--- a/dist/directional avatar.js
+++ b/dist/directional avatar.js
@@ -3,7 +3,7 @@
 @file directional avatar
 @summary flips the player's sprite based on directional movement
 @license MIT
-@version 1.0.3
+@version 1.0.4
 @author Sean S. LeBlanc
 
 @description
@@ -101,7 +101,7 @@ function unique(array) {
 @file kitsy-script-toolkit
 @summary makes it easier and cleaner to run code before and after Bitsy functions or to inject new code into Bitsy script tags
 @license WTFPL (do WTF you want)
-@version 3.2.1
+@version 3.2.2
 @requires Bitsy Version: 4.5, 4.6
 @author @mildmojo
 
@@ -205,7 +205,8 @@ function applyHook(functionName) {
 				functions[i++].apply(this, args.concat(runBefore.bind(this)));
 			} else {
 				// run synchronously
-				var newArgs = functions[i++].apply(this, args) || args;
+				var newArgs = functions[i++].apply(this, args);
+				newArgs = newArgs && newArgs.length ? newArgs : args;
 				runBefore.apply(this, newArgs);
 			}
 		}

--- a/dist/edit dialog from dialog.js
+++ b/dist/edit dialog from dialog.js
@@ -3,7 +3,7 @@
 @file edit dialog from dialog
 @summary edit dialog from dialog (yes really)
 @license MIT
-@version 1.0.1
+@version 1.0.2
 @author Sean S. LeBlanc
 
 @description
@@ -102,7 +102,7 @@ function unique(array) {
 @file kitsy-script-toolkit
 @summary makes it easier and cleaner to run code before and after Bitsy functions or to inject new code into Bitsy script tags
 @license WTFPL (do WTF you want)
-@version 3.2.1
+@version 3.2.2
 @requires Bitsy Version: 4.5, 4.6
 @author @mildmojo
 
@@ -225,7 +225,8 @@ function applyHook(functionName) {
 				functions[i++].apply(this, args.concat(runBefore.bind(this)));
 			} else {
 				// run synchronously
-				var newArgs = functions[i++].apply(this, args) || args;
+				var newArgs = functions[i++].apply(this, args);
+				newArgs = newArgs && newArgs.length ? newArgs : args;
 				runBefore.apply(this, newArgs);
 			}
 		}
@@ -264,8 +265,8 @@ function addDialogFunction(tag, fn) {
 	}
 
 	// Hook into game load and rewrite custom functions in game data to Bitsy format.
-	before('load_game', function (game_data, startWithTitle) {
-		return [convertDialogTags(game_data, tag), startWithTitle];
+	before('parseWorld', function (game_data) {
+		return [convertDialogTags(game_data, tag)];
 	});
 
 	kitsy.dialogFunctions[tag] = fn;

--- a/dist/edit image from dialog.js
+++ b/dist/edit image from dialog.js
@@ -3,7 +3,7 @@
 @file edit image from dialog
 @summary edit sprites, items, and tiles from dialog
 @license MIT
-@version 1.1.1
+@version 1.1.2
 @author Sean S. LeBlanc
 
 @description
@@ -132,7 +132,7 @@ function unique(array) {
 @file kitsy-script-toolkit
 @summary makes it easier and cleaner to run code before and after Bitsy functions or to inject new code into Bitsy script tags
 @license WTFPL (do WTF you want)
-@version 3.2.1
+@version 3.2.2
 @requires Bitsy Version: 4.5, 4.6
 @author @mildmojo
 
@@ -255,7 +255,8 @@ function applyHook(functionName) {
 				functions[i++].apply(this, args.concat(runBefore.bind(this)));
 			} else {
 				// run synchronously
-				var newArgs = functions[i++].apply(this, args) || args;
+				var newArgs = functions[i++].apply(this, args);
+				newArgs = newArgs && newArgs.length ? newArgs : args;
 				runBefore.apply(this, newArgs);
 			}
 		}
@@ -294,8 +295,8 @@ function addDialogFunction(tag, fn) {
 	}
 
 	// Hook into game load and rewrite custom functions in game data to Bitsy format.
-	before('load_game', function (game_data, startWithTitle) {
-		return [convertDialogTags(game_data, tag), startWithTitle];
+	before('parseWorld', function (game_data) {
+		return [convertDialogTags(game_data, tag)];
 	});
 
 	kitsy.dialogFunctions[tag] = fn;

--- a/dist/end-from-dialog.js
+++ b/dist/end-from-dialog.js
@@ -3,7 +3,7 @@
 @file end-from-dialog
 @summary trigger an ending from dialog, including narration text
 @license WTFPL (do WTF you want)
-@version 3.1.1
+@version 3.1.2
 @requires Bitsy Version: 4.5, 4.6
 @author @mildmojo
 
@@ -104,7 +104,7 @@ function unique(array) {
 @file kitsy-script-toolkit
 @summary makes it easier and cleaner to run code before and after Bitsy functions or to inject new code into Bitsy script tags
 @license WTFPL (do WTF you want)
-@version 3.2.1
+@version 3.2.2
 @requires Bitsy Version: 4.5, 4.6
 @author @mildmojo
 
@@ -227,7 +227,8 @@ function applyHook(functionName) {
 				functions[i++].apply(this, args.concat(runBefore.bind(this)));
 			} else {
 				// run synchronously
-				var newArgs = functions[i++].apply(this, args) || args;
+				var newArgs = functions[i++].apply(this, args);
+				newArgs = newArgs && newArgs.length ? newArgs : args;
 				runBefore.apply(this, newArgs);
 			}
 		}
@@ -266,8 +267,8 @@ function addDialogFunction(tag, fn) {
 	}
 
 	// Hook into game load and rewrite custom functions in game data to Bitsy format.
-	before('load_game', function (game_data, startWithTitle) {
-		return [convertDialogTags(game_data, tag), startWithTitle];
+	before('parseWorld', function (game_data) {
+		return [convertDialogTags(game_data, tag)];
 	});
 
 	kitsy.dialogFunctions[tag] = fn;

--- a/dist/exit-from-dialog.js
+++ b/dist/exit-from-dialog.js
@@ -3,7 +3,7 @@
 @file exit-from-dialog
 @summary exit to another room from dialog, including conditionals
 @license WTFPL (do WTF you want)
-@version 5.1.1
+@version 5.1.2
 @requires Bitsy Version: 4.5, 4.6
 @author @mildmojo
 
@@ -115,7 +115,7 @@ function unique(array) {
 @file kitsy-script-toolkit
 @summary makes it easier and cleaner to run code before and after Bitsy functions or to inject new code into Bitsy script tags
 @license WTFPL (do WTF you want)
-@version 3.2.1
+@version 3.2.2
 @requires Bitsy Version: 4.5, 4.6
 @author @mildmojo
 
@@ -238,7 +238,8 @@ function applyHook(functionName) {
 				functions[i++].apply(this, args.concat(runBefore.bind(this)));
 			} else {
 				// run synchronously
-				var newArgs = functions[i++].apply(this, args) || args;
+				var newArgs = functions[i++].apply(this, args);
+				newArgs = newArgs && newArgs.length ? newArgs : args;
 				runBefore.apply(this, newArgs);
 			}
 		}
@@ -277,8 +278,8 @@ function addDialogFunction(tag, fn) {
 	}
 
 	// Hook into game load and rewrite custom functions in game data to Bitsy format.
-	before('load_game', function (game_data, startWithTitle) {
-		return [convertDialogTags(game_data, tag), startWithTitle];
+	before('parseWorld', function (game_data) {
+		return [convertDialogTags(game_data, tag)];
 	});
 
 	kitsy.dialogFunctions[tag] = fn;

--- a/dist/external-game-data.js
+++ b/dist/external-game-data.js
@@ -3,7 +3,7 @@
 @file external-game-data
 @summary separate Bitsy game data from your (modded) HTML for easier development
 @license WTFPL (do WTF you want)
-@version 2.0.2
+@version 2.0.3
 @requires Bitsy Version: 4.5, 4.6
 @author @mildmojo
 
@@ -101,7 +101,7 @@ function unique(array) {
 @file kitsy-script-toolkit
 @summary makes it easier and cleaner to run code before and after Bitsy functions or to inject new code into Bitsy script tags
 @license WTFPL (do WTF you want)
-@version 3.2.1
+@version 3.2.2
 @requires Bitsy Version: 4.5, 4.6
 @author @mildmojo
 
@@ -207,7 +207,8 @@ function applyHook(functionName) {
 				functions[i++].apply(this, args.concat(runBefore.bind(this)));
 			} else {
 				// run synchronously
-				var newArgs = functions[i++].apply(this, args) || args;
+				var newArgs = functions[i++].apply(this, args);
+				newArgs = newArgs && newArgs.length ? newArgs : args;
 				runBefore.apply(this, newArgs);
 			}
 		}

--- a/dist/favicon-from-sprite.js
+++ b/dist/favicon-from-sprite.js
@@ -3,7 +3,7 @@
 @file favicon-from-sprite
 @summary generate a browser favicon (tab icon) from a Bitsy sprite, including animation!
 @license WTFPL (do WTF you want)
-@version 2.0.2
+@version 2.0.3
 @requires Bitsy Version: 4.5, 4.6
 @author @mildmojo
 
@@ -88,7 +88,7 @@ function unique(array) {
 @file kitsy-script-toolkit
 @summary makes it easier and cleaner to run code before and after Bitsy functions or to inject new code into Bitsy script tags
 @license WTFPL (do WTF you want)
-@version 3.2.1
+@version 3.2.2
 @requires Bitsy Version: 4.5, 4.6
 @author @mildmojo
 
@@ -192,7 +192,8 @@ function applyHook(functionName) {
 				functions[i++].apply(this, args.concat(runBefore.bind(this)));
 			} else {
 				// run synchronously
-				var newArgs = functions[i++].apply(this, args) || args;
+				var newArgs = functions[i++].apply(this, args);
+				newArgs = newArgs && newArgs.length ? newArgs : args;
 				runBefore.apply(this, newArgs);
 			}
 		}

--- a/dist/gamepad input.js
+++ b/dist/gamepad input.js
@@ -3,7 +3,7 @@
 @file gamepad input
 @summary HTML5 gamepad support
 @license MIT
-@version 2.0.1
+@version 2.0.2
 @requires Bitsy Version: 5.1
 @author Sean S. LeBlanc
 
@@ -442,7 +442,7 @@ function unique(array) {
 @file kitsy-script-toolkit
 @summary makes it easier and cleaner to run code before and after Bitsy functions or to inject new code into Bitsy script tags
 @license WTFPL (do WTF you want)
-@version 3.2.1
+@version 3.2.2
 @requires Bitsy Version: 4.5, 4.6
 @author @mildmojo
 
@@ -555,7 +555,8 @@ function applyHook(functionName) {
 				functions[i++].apply(this, args.concat(runBefore.bind(this)));
 			} else {
 				// run synchronously
-				var newArgs = functions[i++].apply(this, args) || args;
+				var newArgs = functions[i++].apply(this, args);
+				newArgs = newArgs && newArgs.length ? newArgs : args;
 				runBefore.apply(this, newArgs);
 			}
 		}

--- a/dist/itsy-bitsy.js
+++ b/dist/itsy-bitsy.js
@@ -3,7 +3,7 @@
 @file itsy-bitsy
 @summary for when bitsy's not small enough
 @license MIT
-@version 1.0.2
+@version 1.0.3
 @requires Bitsy Version: 5.1
 @author Sean S. LeBlanc
 
@@ -89,7 +89,7 @@ function unique(array) {
 @file kitsy-script-toolkit
 @summary makes it easier and cleaner to run code before and after Bitsy functions or to inject new code into Bitsy script tags
 @license WTFPL (do WTF you want)
-@version 3.2.1
+@version 3.2.2
 @requires Bitsy Version: 4.5, 4.6
 @author @mildmojo
 
@@ -196,7 +196,8 @@ function applyHook(functionName) {
 				functions[i++].apply(this, args.concat(runBefore.bind(this)));
 			} else {
 				// run synchronously
-				var newArgs = functions[i++].apply(this, args) || args;
+				var newArgs = functions[i++].apply(this, args);
+				newArgs = newArgs && newArgs.length ? newArgs : args;
 				runBefore.apply(this, newArgs);
 			}
 		}

--- a/dist/javascript dialog.js
+++ b/dist/javascript dialog.js
@@ -3,7 +3,7 @@
 @file javascript dialog
 @summary execute arbitrary javascript from dialog
 @license MIT
-@version 3.1.1
+@version 3.1.2
 @requires Bitsy Version: 4.5, 4.6
 @author Sean S. LeBlanc
 
@@ -100,7 +100,7 @@ function unique(array) {
 @file kitsy-script-toolkit
 @summary makes it easier and cleaner to run code before and after Bitsy functions or to inject new code into Bitsy script tags
 @license WTFPL (do WTF you want)
-@version 3.2.1
+@version 3.2.2
 @requires Bitsy Version: 4.5, 4.6
 @author @mildmojo
 
@@ -223,7 +223,8 @@ function applyHook(functionName) {
 				functions[i++].apply(this, args.concat(runBefore.bind(this)));
 			} else {
 				// run synchronously
-				var newArgs = functions[i++].apply(this, args) || args;
+				var newArgs = functions[i++].apply(this, args);
+				newArgs = newArgs && newArgs.length ? newArgs : args;
 				runBefore.apply(this, newArgs);
 			}
 		}
@@ -262,8 +263,8 @@ function addDialogFunction(tag, fn) {
 	}
 
 	// Hook into game load and rewrite custom functions in game data to Bitsy format.
-	before('load_game', function (game_data, startWithTitle) {
-		return [convertDialogTags(game_data, tag), startWithTitle];
+	before('parseWorld', function (game_data) {
+		return [convertDialogTags(game_data, tag)];
 	});
 
 	kitsy.dialogFunctions[tag] = fn;

--- a/dist/logic-operators-extended.js
+++ b/dist/logic-operators-extended.js
@@ -2,7 +2,7 @@
 🔀
 @file logic-operators-extended
 @summary adds conditional logic operators
-@version 1.0.4
+@version 1.0.5
 @author @mildmojo
 
 @description
@@ -89,7 +89,7 @@ function unique(array) {
 @file kitsy-script-toolkit
 @summary makes it easier and cleaner to run code before and after Bitsy functions or to inject new code into Bitsy script tags
 @license WTFPL (do WTF you want)
-@version 3.2.1
+@version 3.2.2
 @requires Bitsy Version: 4.5, 4.6
 @author @mildmojo
 
@@ -196,7 +196,8 @@ function applyHook(functionName) {
 				functions[i++].apply(this, args.concat(runBefore.bind(this)));
 			} else {
 				// run synchronously
-				var newArgs = functions[i++].apply(this, args) || args;
+				var newArgs = functions[i++].apply(this, args);
+				newArgs = newArgs && newArgs.length ? newArgs : args;
 				runBefore.apply(this, newArgs);
 			}
 		}

--- a/dist/multi-sprite avatar.js
+++ b/dist/multi-sprite avatar.js
@@ -3,7 +3,7 @@
 @file multi-sprite avatar
 @summary make the player big
 @license MIT
-@version 2.0.1
+@version 2.0.2
 @author Sean S. LeBlanc
 
 @description
@@ -120,7 +120,7 @@ function unique(array) {
 @file kitsy-script-toolkit
 @summary makes it easier and cleaner to run code before and after Bitsy functions or to inject new code into Bitsy script tags
 @license WTFPL (do WTF you want)
-@version 3.2.1
+@version 3.2.2
 @requires Bitsy Version: 4.5, 4.6
 @author @mildmojo
 
@@ -233,7 +233,8 @@ function applyHook(functionName) {
 				functions[i++].apply(this, args.concat(runBefore.bind(this)));
 			} else {
 				// run synchronously
-				var newArgs = functions[i++].apply(this, args) || args;
+				var newArgs = functions[i++].apply(this, args);
+				newArgs = newArgs && newArgs.length ? newArgs : args;
 				runBefore.apply(this, newArgs);
 			}
 		}

--- a/dist/online.js
+++ b/dist/online.js
@@ -3,7 +3,7 @@
 @file online
 @summary multiplayer bitsy
 @license MIT
-@version 2.0.1
+@version 2.0.2
 @author Sean S. LeBlanc
 @description
 Provides the groundwork for running a small online multiplayer bitsy game.
@@ -113,7 +113,7 @@ function unique(array) {
 @file kitsy-script-toolkit
 @summary makes it easier and cleaner to run code before and after Bitsy functions or to inject new code into Bitsy script tags
 @license WTFPL (do WTF you want)
-@version 3.2.1
+@version 3.2.2
 @requires Bitsy Version: 4.5, 4.6
 @author @mildmojo
 
@@ -236,7 +236,8 @@ function applyHook(functionName) {
 				functions[i++].apply(this, args.concat(runBefore.bind(this)));
 			} else {
 				// run synchronously
-				var newArgs = functions[i++].apply(this, args) || args;
+				var newArgs = functions[i++].apply(this, args);
+				newArgs = newArgs && newArgs.length ? newArgs : args;
 				runBefore.apply(this, newArgs);
 			}
 		}
@@ -275,8 +276,8 @@ function addDialogFunction(tag, fn) {
 	}
 
 	// Hook into game load and rewrite custom functions in game data to Bitsy format.
-	before('load_game', function (game_data, startWithTitle) {
-		return [convertDialogTags(game_data, tag), startWithTitle];
+	before('parseWorld', function (game_data) {
+		return [convertDialogTags(game_data, tag)];
 	});
 
 	kitsy.dialogFunctions[tag] = fn;
@@ -341,7 +342,7 @@ function addDeferredDialogTag(tag, fn) {
 @file javascript dialog
 @summary execute arbitrary javascript from dialog
 @license MIT
-@version 3.1.1
+@version 3.1.2
 @requires Bitsy Version: 4.5, 4.6
 @author Sean S. LeBlanc
 
@@ -456,7 +457,7 @@ function setSpriteData(id, frame, newData) {
 @file edit image from dialog
 @summary edit sprites, items, and tiles from dialog
 @license MIT
-@version 1.1.1
+@version 1.1.2
 @author Sean S. LeBlanc
 
 @description
@@ -615,7 +616,7 @@ addDialogTag('imagePalNow', editPalette);
 @file edit dialog from dialog
 @summary edit dialog from dialog (yes really)
 @license MIT
-@version 1.0.1
+@version 1.0.2
 @author Sean S. LeBlanc
 
 @description

--- a/dist/paragraph-break.js
+++ b/dist/paragraph-break.js
@@ -3,7 +3,7 @@
 @file paragraph-break
 @summary Adds paragraph breaks to the dialogue parser
 @license WTFPL (do WTF you want)
-@version 1.0.1
+@version 1.0.2
 @requires Bitsy Version: 5.0, 5.1
 @author Sean S. LeBlanc, David Mowatt
 
@@ -92,7 +92,7 @@ function unique(array) {
 @file kitsy-script-toolkit
 @summary makes it easier and cleaner to run code before and after Bitsy functions or to inject new code into Bitsy script tags
 @license WTFPL (do WTF you want)
-@version 3.2.1
+@version 3.2.2
 @requires Bitsy Version: 4.5, 4.6
 @author @mildmojo
 
@@ -208,7 +208,8 @@ function applyHook(functionName) {
 				functions[i++].apply(this, args.concat(runBefore.bind(this)));
 			} else {
 				// run synchronously
-				var newArgs = functions[i++].apply(this, args) || args;
+				var newArgs = functions[i++].apply(this, args);
+				newArgs = newArgs && newArgs.length ? newArgs : args;
 				runBefore.apply(this, newArgs);
 			}
 		}
@@ -247,8 +248,8 @@ function addDialogFunction(tag, fn) {
 	}
 
 	// Hook into game load and rewrite custom functions in game data to Bitsy format.
-	before('load_game', function (game_data, startWithTitle) {
-		return [convertDialogTags(game_data, tag), startWithTitle];
+	before('parseWorld', function (game_data) {
+		return [convertDialogTags(game_data, tag)];
 	});
 
 	kitsy.dialogFunctions[tag] = fn;

--- a/dist/permanent items.js
+++ b/dist/permanent items.js
@@ -3,7 +3,7 @@
 @file permanent items
 @summary prevent some items from being picked up
 @license MIT
-@version 2.0.1
+@version 2.0.2
 @author Sean S. LeBlanc
 
 @description
@@ -83,7 +83,7 @@ function unique(array) {
 @file kitsy-script-toolkit
 @summary makes it easier and cleaner to run code before and after Bitsy functions or to inject new code into Bitsy script tags
 @license WTFPL (do WTF you want)
-@version 3.2.1
+@version 3.2.2
 @requires Bitsy Version: 4.5, 4.6
 @author @mildmojo
 
@@ -196,7 +196,8 @@ function applyHook(functionName) {
 				functions[i++].apply(this, args.concat(runBefore.bind(this)));
 			} else {
 				// run synchronously
-				var newArgs = functions[i++].apply(this, args) || args;
+				var newArgs = functions[i++].apply(this, args);
+				newArgs = newArgs && newArgs.length ? newArgs : args;
 				runBefore.apply(this, newArgs);
 			}
 		}

--- a/dist/solid items.js
+++ b/dist/solid items.js
@@ -3,7 +3,7 @@
 @file solid items
 @summary treat some items like sprites that can be placed multiple times
 @license MIT
-@version 2.0.0
+@version 2.0.1
 @author Sean S. LeBlanc
 
 @description
@@ -84,7 +84,7 @@ function unique(array) {
 @file kitsy-script-toolkit
 @summary makes it easier and cleaner to run code before and after Bitsy functions or to inject new code into Bitsy script tags
 @license WTFPL (do WTF you want)
-@version 3.2.1
+@version 3.2.2
 @requires Bitsy Version: 4.5, 4.6
 @author @mildmojo
 
@@ -197,7 +197,8 @@ function applyHook(functionName) {
 				functions[i++].apply(this, args.concat(runBefore.bind(this)));
 			} else {
 				// run synchronously
-				var newArgs = functions[i++].apply(this, args) || args;
+				var newArgs = functions[i++].apply(this, args);
+				newArgs = newArgs && newArgs.length ? newArgs : args;
 				runBefore.apply(this, newArgs);
 			}
 		}

--- a/dist/stopwatch.js
+++ b/dist/stopwatch.js
@@ -3,7 +3,7 @@
 @file stopwatch
 @summary time player actions
 @license MIT
-@version 1.1.1
+@version 1.1.2
 @author Lenny Magner
 
 @description
@@ -136,7 +136,7 @@ function printDialog(environment, text, onReturn) {
 @file kitsy-script-toolkit
 @summary makes it easier and cleaner to run code before and after Bitsy functions or to inject new code into Bitsy script tags
 @license WTFPL (do WTF you want)
-@version 3.2.1
+@version 3.2.2
 @requires Bitsy Version: 4.5, 4.6
 @author @mildmojo
 
@@ -259,7 +259,8 @@ function applyHook(functionName) {
 				functions[i++].apply(this, args.concat(runBefore.bind(this)));
 			} else {
 				// run synchronously
-				var newArgs = functions[i++].apply(this, args) || args;
+				var newArgs = functions[i++].apply(this, args);
+				newArgs = newArgs && newArgs.length ? newArgs : args;
 				runBefore.apply(this, newArgs);
 			}
 		}
@@ -298,8 +299,8 @@ function addDialogFunction(tag, fn) {
 	}
 
 	// Hook into game load and rewrite custom functions in game data to Bitsy format.
-	before('load_game', function (game_data, startWithTitle) {
-		return [convertDialogTags(game_data, tag), startWithTitle];
+	before('parseWorld', function (game_data) {
+		return [convertDialogTags(game_data, tag)];
 	});
 
 	kitsy.dialogFunctions[tag] = fn;

--- a/dist/transparent dialog.js
+++ b/dist/transparent dialog.js
@@ -3,7 +3,7 @@
 @file transparent dialog
 @summary makes the dialog box have a transparent background
 @license MIT
-@version 1.0.2
+@version 1.0.3
 @author Sean S. LeBlanc
 
 @description
@@ -76,7 +76,7 @@ function unique(array) {
 @file kitsy-script-toolkit
 @summary makes it easier and cleaner to run code before and after Bitsy functions or to inject new code into Bitsy script tags
 @license WTFPL (do WTF you want)
-@version 3.2.1
+@version 3.2.2
 @requires Bitsy Version: 4.5, 4.6
 @author @mildmojo
 
@@ -183,7 +183,8 @@ function applyHook(functionName) {
 				functions[i++].apply(this, args.concat(runBefore.bind(this)));
 			} else {
 				// run synchronously
-				var newArgs = functions[i++].apply(this, args) || args;
+				var newArgs = functions[i++].apply(this, args);
+				newArgs = newArgs && newArgs.length ? newArgs : args;
 				runBefore.apply(this, newArgs);
 			}
 		}

--- a/dist/transparent sprites.js
+++ b/dist/transparent sprites.js
@@ -3,7 +3,7 @@
 @file transparent sprites
 @summary makes all sprites have transparent backgrounds
 @license MIT
-@version 2.0.1
+@version 2.0.2
 @requires Bitsy Version: 5.1
 @author Sean S. LeBlanc
 
@@ -76,7 +76,7 @@ function unique(array) {
 @file kitsy-script-toolkit
 @summary makes it easier and cleaner to run code before and after Bitsy functions or to inject new code into Bitsy script tags
 @license WTFPL (do WTF you want)
-@version 3.2.1
+@version 3.2.2
 @requires Bitsy Version: 4.5, 4.6
 @author @mildmojo
 
@@ -183,7 +183,8 @@ function applyHook(functionName) {
 				functions[i++].apply(this, args.concat(runBefore.bind(this)));
 			} else {
 				// run synchronously
-				var newArgs = functions[i++].apply(this, args) || args;
+				var newArgs = functions[i++].apply(this, args);
+				newArgs = newArgs && newArgs.length ? newArgs : args;
 				runBefore.apply(this, newArgs);
 			}
 		}

--- a/src/bitsymuse.js
+++ b/src/bitsymuse.js
@@ -3,7 +3,7 @@
 @file bitsymuse
 @summary A variety of Bitsy sound and music handlers
 @license MIT
-@version 2.1.1
+@version 2.1.2
 @requires 4.8, 4.9
 @author David Mowatt
 

--- a/src/canvas replacement.js
+++ b/src/canvas replacement.js
@@ -3,7 +3,7 @@
 @file canvas replacement
 @summary WebGLazy bitsy integration (this one's mostly just for me)
 @license MIT
-@version 1.1.1
+@version 1.1.2
 @author Sean S. LeBlanc
 
 @description

--- a/src/custom text effect.js
+++ b/src/custom text effect.js
@@ -3,7 +3,7 @@
 @file custom text effect
 @summary make {custom}text effects{custom}
 @license MIT
-@version 1.0.2
+@version 1.0.3
 @author Sean S. LeBlanc
 
 @description

--- a/src/directional avatar.js
+++ b/src/directional avatar.js
@@ -3,7 +3,7 @@
 @file directional avatar
 @summary flips the player's sprite based on directional movement
 @license MIT
-@version 1.0.3
+@version 1.0.4
 @author Sean S. LeBlanc
 
 @description

--- a/src/edit dialog from dialog.js
+++ b/src/edit dialog from dialog.js
@@ -3,7 +3,7 @@
 @file edit dialog from dialog
 @summary edit dialog from dialog (yes really)
 @license MIT
-@version 1.0.1
+@version 1.0.2
 @author Sean S. LeBlanc
 
 @description

--- a/src/edit image from dialog.js
+++ b/src/edit image from dialog.js
@@ -3,7 +3,7 @@
 @file edit image from dialog
 @summary edit sprites, items, and tiles from dialog
 @license MIT
-@version 1.1.1
+@version 1.1.2
 @author Sean S. LeBlanc
 
 @description

--- a/src/end-from-dialog.js
+++ b/src/end-from-dialog.js
@@ -3,7 +3,7 @@
 @file end-from-dialog
 @summary trigger an ending from dialog, including narration text
 @license WTFPL (do WTF you want)
-@version 3.1.1
+@version 3.1.2
 @requires Bitsy Version: 4.5, 4.6
 @author @mildmojo
 

--- a/src/exit-from-dialog.js
+++ b/src/exit-from-dialog.js
@@ -3,7 +3,7 @@
 @file exit-from-dialog
 @summary exit to another room from dialog, including conditionals
 @license WTFPL (do WTF you want)
-@version 5.1.1
+@version 5.1.2
 @requires Bitsy Version: 4.5, 4.6
 @author @mildmojo
 

--- a/src/external-game-data.js
+++ b/src/external-game-data.js
@@ -3,7 +3,7 @@
 @file external-game-data
 @summary separate Bitsy game data from your (modded) HTML for easier development
 @license WTFPL (do WTF you want)
-@version 2.0.2
+@version 2.0.3
 @requires Bitsy Version: 4.5, 4.6
 @author @mildmojo
 

--- a/src/favicon-from-sprite.js
+++ b/src/favicon-from-sprite.js
@@ -3,7 +3,7 @@
 @file favicon-from-sprite
 @summary generate a browser favicon (tab icon) from a Bitsy sprite, including animation!
 @license WTFPL (do WTF you want)
-@version 2.0.2
+@version 2.0.3
 @requires Bitsy Version: 4.5, 4.6
 @author @mildmojo
 

--- a/src/gamepad input.js
+++ b/src/gamepad input.js
@@ -3,7 +3,7 @@
 @file gamepad input
 @summary HTML5 gamepad support
 @license MIT
-@version 2.0.1
+@version 2.0.2
 @requires Bitsy Version: 5.1
 @author Sean S. LeBlanc
 

--- a/src/helpers/kitsy-script-toolkit.js
+++ b/src/helpers/kitsy-script-toolkit.js
@@ -131,7 +131,8 @@ function applyHook(functionName) {
 				functions[i++].apply(this, args.concat(runBefore.bind(this)));
 			} else {
 				// run synchronously
-				var newArgs = functions[i++].apply(this, args) || args;
+				var newArgs = functions[i++].apply(this, args);
+				newArgs = newArgs && newArgs.length ? newArgs : args;
 				runBefore.apply(this, newArgs);
 			}
 		}
@@ -170,8 +171,8 @@ function addDialogFunction(tag, fn) {
 	}
 
 	// Hook into game load and rewrite custom functions in game data to Bitsy format.
-	before('load_game', function (game_data, startWithTitle) {
-		return [convertDialogTags(game_data, tag), startWithTitle];
+	before('parseWorld', function (game_data) {
+		return [convertDialogTags(game_data, tag)];
 	});
 
 	kitsy.dialogFunctions[tag] = fn;

--- a/src/helpers/kitsy-script-toolkit.js
+++ b/src/helpers/kitsy-script-toolkit.js
@@ -3,7 +3,7 @@
 @file kitsy-script-toolkit
 @summary makes it easier and cleaner to run code before and after Bitsy functions or to inject new code into Bitsy script tags
 @license WTFPL (do WTF you want)
-@version 3.2.1
+@version 3.2.2
 @requires Bitsy Version: 4.5, 4.6
 @author @mildmojo
 

--- a/src/itsy-bitsy.js
+++ b/src/itsy-bitsy.js
@@ -3,7 +3,7 @@
 @file itsy-bitsy
 @summary for when bitsy's not small enough
 @license MIT
-@version 1.0.2
+@version 1.0.3
 @requires Bitsy Version: 5.1
 @author Sean S. LeBlanc
 

--- a/src/javascript dialog.js
+++ b/src/javascript dialog.js
@@ -3,7 +3,7 @@
 @file javascript dialog
 @summary execute arbitrary javascript from dialog
 @license MIT
-@version 3.1.1
+@version 3.1.2
 @requires Bitsy Version: 4.5, 4.6
 @author Sean S. LeBlanc
 

--- a/src/logic-operators-extended.js
+++ b/src/logic-operators-extended.js
@@ -2,7 +2,7 @@
 🔀
 @file logic-operators-extended
 @summary adds conditional logic operators
-@version 1.0.4
+@version 1.0.5
 @author @mildmojo
 
 @description

--- a/src/multi-sprite avatar.js
+++ b/src/multi-sprite avatar.js
@@ -3,7 +3,7 @@
 @file multi-sprite avatar
 @summary make the player big
 @license MIT
-@version 2.0.1
+@version 2.0.2
 @author Sean S. LeBlanc
 
 @description

--- a/src/online.js
+++ b/src/online.js
@@ -3,7 +3,7 @@
 @file online
 @summary multiplayer bitsy
 @license MIT
-@version 2.0.1
+@version 2.0.2
 @author Sean S. LeBlanc
 @description
 Provides the groundwork for running a small online multiplayer bitsy game.

--- a/src/paragraph-break.js
+++ b/src/paragraph-break.js
@@ -3,7 +3,7 @@
 @file paragraph-break
 @summary Adds paragraph breaks to the dialogue parser
 @license WTFPL (do WTF you want)
-@version 1.0.1
+@version 1.0.2
 @requires Bitsy Version: 5.0, 5.1
 @author Sean S. LeBlanc, David Mowatt
 

--- a/src/permanent items.js
+++ b/src/permanent items.js
@@ -3,7 +3,7 @@
 @file permanent items
 @summary prevent some items from being picked up
 @license MIT
-@version 2.0.1
+@version 2.0.2
 @author Sean S. LeBlanc
 
 @description

--- a/src/solid items.js
+++ b/src/solid items.js
@@ -3,7 +3,7 @@
 @file solid items
 @summary treat some items like sprites that can be placed multiple times
 @license MIT
-@version 2.0.0
+@version 2.0.1
 @author Sean S. LeBlanc
 
 @description

--- a/src/stopwatch.js
+++ b/src/stopwatch.js
@@ -3,7 +3,7 @@
 @file stopwatch
 @summary time player actions
 @license MIT
-@version 1.1.1
+@version 1.1.2
 @author Lenny Magner
 
 @description

--- a/src/transparent dialog.js
+++ b/src/transparent dialog.js
@@ -3,7 +3,7 @@
 @file transparent dialog
 @summary makes the dialog box have a transparent background
 @license MIT
-@version 1.0.2
+@version 1.0.3
 @author Sean S. LeBlanc
 
 @description

--- a/src/transparent sprites.js
+++ b/src/transparent sprites.js
@@ -3,7 +3,7 @@
 @file transparent sprites
 @summary makes all sprites have transparent backgrounds
 @license MIT
-@version 2.0.1
+@version 2.0.2
 @requires Bitsy Version: 5.1
 @author Sean S. LeBlanc
 


### PR DESCRIPTION
bitsy saves the gamedata arg of `load_game` and uses it when resetting the game, which meant that the escaped commands were converted to real commands on reload. this fixes the issue by applying dialog hacks to gamedata on `parseWorld` instead of `load_game`, allowing their effects to be seen without mutating data