### PR TITLE
update canvas replacement options

### DIFF
--- a/dist/canvas-replacement.js
+++ b/dist/canvas-replacement.js
@@ -3,7 +3,7 @@
 @file canvas replacement
 @summary WebGLazy bitsy integration (this one's mostly just for me)
 @license MIT
-@version 1.1.2
+@version 2.0.0
 @author Sean S. LeBlanc
 
 @description
@@ -38,15 +38,17 @@ e.g.
 (function (bitsy) {
 'use strict';
 var hackOptions = {
-	background: "black",
-	scaleMode: "MULTIPLES", // use "FIT" if you prefer size to pixel accuracy
-	allowDownscaling: true,
-	disableFeedbackTexture: true, // set this to false if you want to use the feedback texture
-	init: function() {
+	glazyOptions: {
+		background: "black",
+		scaleMode: "MULTIPLES", // use "FIT" if you prefer size to pixel accuracy
+		allowDownscaling: true,
+		disableFeedbackTexture: true, // set this to false if you want to use the feedback texture
+	},
+	init: function(glazy) {
 		// you can set up any custom uniforms you have here if needed
 		// e.g. glazy.glLocations.myUniform = glazy.gl.getUniformLocation(glazy.shader.program, 'myUniform');
 	},
-	update: function() {
+	update: function(glazy) {
 		// you can update any custom uniforms you have here if needed
 		// e.g. glazy.gl.uniform1f(glazy.glLocations.myUniform, 0);
 	},
@@ -242,12 +244,12 @@ function _reinitEngine() {
 
 var glazy;
 after('startExportedGame', function () {
-	glazy = new WebGLazy(hackOptions);
-	hackOptions.init();
+	glazy = new WebGLazy(hackOptions.glazyOptions);
+	hackOptions.init(glazy);
 });
 
 after('update', function () {
-	hackOptions.update();
+	hackOptions.update(glazy);
 });
 
 }(window));

--- a/dist/transitions.js
+++ b/dist/transitions.js
@@ -3,7 +3,7 @@
 @file transitions
 @summary customizable WebGL transitions
 @license MIT
-@version 1.1.0
+@version 2.0.0
 @author Sean S. LeBlanc
 
 @description
@@ -266,7 +266,7 @@ function _reinitEngine() {
 @file canvas replacement
 @summary WebGLazy bitsy integration (this one's mostly just for me)
 @license MIT
-@version 1.1.2
+@version 2.0.0
 @author Sean S. LeBlanc
 
 @description
@@ -300,15 +300,17 @@ e.g.
 */
 
 var hackOptions = {
-	background: "black",
-	scaleMode: "MULTIPLES", // use "FIT" if you prefer size to pixel accuracy
-	allowDownscaling: true,
-	disableFeedbackTexture: true, // set this to false if you want to use the feedback texture
-	init: function() {
+	glazyOptions: {
+		background: "black",
+		scaleMode: "MULTIPLES", // use "FIT" if you prefer size to pixel accuracy
+		allowDownscaling: true,
+		disableFeedbackTexture: true, // set this to false if you want to use the feedback texture
+	},
+	init: function(glazy) {
 		// you can set up any custom uniforms you have here if needed
 		// e.g. glazy.glLocations.myUniform = glazy.gl.getUniformLocation(glazy.shader.program, 'myUniform');
 	},
-	update: function() {
+	update: function(glazy) {
 		// you can update any custom uniforms you have here if needed
 		// e.g. glazy.gl.uniform1f(glazy.glLocations.myUniform, 0);
 	},
@@ -316,20 +318,20 @@ var hackOptions = {
 
 var glazy;
 after('startExportedGame', function () {
-	glazy = new WebGLazy(hackOptions);
-	hackOptions.init();
+	glazy = new WebGLazy(hackOptions.glazyOptions);
+	hackOptions.init(glazy);
 });
 
 after('update', function () {
-	hackOptions.update();
+	hackOptions.update(glazy);
 });
 
 
 
 
 
-hackOptions.disableFeedbackTexture = false;
-hackOptions.init = function () {
+hackOptions.glazyOptions.disableFeedbackTexture = false;
+hackOptions.init = function (glazy) {
 	glazy.glLocations.transitionTime = glazy.gl.getUniformLocation(glazy.shader.program, 'transitionTime');
 	if (!hackOptions$1.includeTitle) {
 		glazy.gl.uniform1f(glazy.glLocations.transitionTime, glazy.curTime - hackOptions$1.duration);
@@ -340,7 +342,7 @@ hackOptions.init = function () {
 	glazy.textureFeedback.oldUpdate = glazy.textureFeedback.update;
 	glazy.textureFeedback.update = function () {};
 };
-hackOptions.update = function () {
+hackOptions.update = function (glazy) {
 	if (hackOptions$1.checkTransition()) {
 		// transition occurred; update feedback texture to capture frame
 		glazy.gl.uniform1f(glazy.glLocations.transitionTime, glazy.curTime);

--- a/src/canvas replacement.js
+++ b/src/canvas replacement.js
@@ -3,7 +3,7 @@
 @file canvas replacement
 @summary WebGLazy bitsy integration (this one's mostly just for me)
 @license MIT
-@version 1.1.2
+@version 2.0.0
 @author Sean S. LeBlanc
 
 @description

--- a/src/canvas replacement.js
+++ b/src/canvas replacement.js
@@ -41,28 +41,28 @@ import {
 } from "./helpers/kitsy-script-toolkit";
 
 export var hackOptions = {
-	init: function() {
 	glazyOptions: {
 		background: "black",
 		scaleMode: "MULTIPLES", // use "FIT" if you prefer size to pixel accuracy
 		allowDownscaling: true,
 		disableFeedbackTexture: true, // set this to false if you want to use the feedback texture
 	},
+	init: function(glazy) {
 		// you can set up any custom uniforms you have here if needed
 		// e.g. glazy.glLocations.myUniform = glazy.gl.getUniformLocation(glazy.shader.program, 'myUniform');
 	},
-	update: function() {
+	update: function(glazy) {
 		// you can update any custom uniforms you have here if needed
 		// e.g. glazy.gl.uniform1f(glazy.glLocations.myUniform, 0);
 	},
 };
 
-export var glazy;
+var glazy;
 after('startExportedGame', function () {
-	hackOptions.init();
 	glazy = new WebGLazy(hackOptions.glazyOptions);
+	hackOptions.init(glazy);
 });
 
 after('update', function () {
-	hackOptions.update();
+	hackOptions.update(glazy);
 });

--- a/src/canvas replacement.js
+++ b/src/canvas replacement.js
@@ -41,11 +41,13 @@ import {
 } from "./helpers/kitsy-script-toolkit";
 
 export var hackOptions = {
-	background: "black",
-	scaleMode: "MULTIPLES", // use "FIT" if you prefer size to pixel accuracy
-	allowDownscaling: true,
-	disableFeedbackTexture: true, // set this to false if you want to use the feedback texture
 	init: function() {
+	glazyOptions: {
+		background: "black",
+		scaleMode: "MULTIPLES", // use "FIT" if you prefer size to pixel accuracy
+		allowDownscaling: true,
+		disableFeedbackTexture: true, // set this to false if you want to use the feedback texture
+	},
 		// you can set up any custom uniforms you have here if needed
 		// e.g. glazy.glLocations.myUniform = glazy.gl.getUniformLocation(glazy.shader.program, 'myUniform');
 	},
@@ -57,8 +59,8 @@ export var hackOptions = {
 
 export var glazy;
 after('startExportedGame', function () {
-	glazy = new WebGLazy(hackOptions);
 	hackOptions.init();
+	glazy = new WebGLazy(hackOptions.glazyOptions);
 });
 
 after('update', function () {

--- a/src/transitions.js
+++ b/src/transitions.js
@@ -3,7 +3,7 @@
 @file transitions
 @summary customizable WebGL transitions
 @license MIT
-@version 1.1.0
+@version 2.0.0
 @author Sean S. LeBlanc
 
 @description

--- a/src/transitions.js
+++ b/src/transitions.js
@@ -56,8 +56,7 @@ NOTES:
 */
 import bitsy from "bitsy";
 import {
-	hackOptions as canvasReplacementHackOptions,
-	glazy
+	hackOptions as canvasReplacementHackOptions
 } from "./canvas replacement";
 
 export var hackOptions = {
@@ -81,8 +80,8 @@ export var hackOptions = {
 	transition: 'result = mix(start, end, t);',
 };
 
-canvasReplacementHackOptions.init = function () {
 canvasReplacementHackOptions.glazyOptions.disableFeedbackTexture = false;
+canvasReplacementHackOptions.init = function (glazy) {
 	glazy.glLocations.transitionTime = glazy.gl.getUniformLocation(glazy.shader.program, 'transitionTime');
 	if (!hackOptions.includeTitle) {
 		glazy.gl.uniform1f(glazy.glLocations.transitionTime, glazy.curTime - hackOptions.duration);
@@ -93,7 +92,7 @@ canvasReplacementHackOptions.glazyOptions.disableFeedbackTexture = false;
 	glazy.textureFeedback.oldUpdate = glazy.textureFeedback.update;
 	glazy.textureFeedback.update = function () {};
 };
-canvasReplacementHackOptions.update = function () {
+canvasReplacementHackOptions.update = function (glazy) {
 	if (hackOptions.checkTransition()) {
 		// transition occurred; update feedback texture to capture frame
 		glazy.gl.uniform1f(glazy.glLocations.transitionTime, glazy.curTime);

--- a/src/transitions.js
+++ b/src/transitions.js
@@ -81,8 +81,8 @@ export var hackOptions = {
 	transition: 'result = mix(start, end, t);',
 };
 
-canvasReplacementHackOptions.disableFeedbackTexture = false;
 canvasReplacementHackOptions.init = function () {
+canvasReplacementHackOptions.glazyOptions.disableFeedbackTexture = false;
 	glazy.glLocations.transitionTime = glazy.gl.getUniformLocation(glazy.shader.program, 'transitionTime');
 	if (!hackOptions.includeTitle) {
 		glazy.gl.uniform1f(glazy.glLocations.transitionTime, glazy.curTime - hackOptions.duration);


### PR DESCRIPTION
- separates options passed to WebGLazy instance from other options
- removes need for exporting instance by passing it to init/update instead