### PR TITLE
Exit from dialog for v6.0

### DIFF
--- a/dist/exit-from-dialog.js
+++ b/dist/exit-from-dialog.js
@@ -3,13 +3,13 @@
 @file exit-from-dialog
 @summary exit to another room from dialog, including conditionals
 @license WTFPL (do WTF you want)
-@version 5.2.2
-@requires Bitsy Version: 4.5, 4.6
+@version 6.0.0
+@requires Bitsy Version: 6.0
 @author @mildmojo
 
 @description
-Lets you exit to another room from dialog (including inside conditionals). Use
-it to make an invisible sprite that acts as a conditional exit, use it to warp
+Lets you exit to another room from dialog (including inside conditionals).
+Use it to make an invisible sprite that acts as a conditional exit, use it to warp
 somewhere after a conversation, use it to put a guard at your gate who only
 lets you in once you're disguised, use it to require payment before the
 ferryman will take you across the river.
@@ -18,30 +18,27 @@ Using the (exit) function in any part of a series of dialog will make the
 game exit to the new room after the dialog is finished. Using (exitNow) will
 immediately warp to the new room, but the current dialog will continue.
 
-WARNING: In exit coordinates, the TOP LEFT tile is (0,0). In sprite coordinates,
-         the BOTTOM LEFT tile is (0,0). If you'd like to use sprite coordinates,
-         add the word "sprite" as the fourth parameter to the exit function.
+Usage:
+	(exit "<room name>,<x>,<y>,<optional transition_effect>")
+	(exitNow "<room name>,<x>,<y>,<optional transition_effect>")
 
-Usage: (exit "<room name>,<x>,<y>")
-       (exit "<room name>,<x>,<y>,sprite")
-       (exitNow "<room name>,<x>,<y>")
-       (exitNow "<room name>,<x>,<y>,sprite")
-
-Example: (exit "FinalRoom,8,4")
-         (exitNow "FinalRoom,8,11,sprite")
+Example:
+	(exit "FinalRoom,8,4")
+	(exit "FinalRoom,8,4,tunnel")
 
 HOW TO USE:
-  1. Copy-paste this script into a new script tag after the Bitsy source code.
-     It should appear *before* any other mods that handle loading your game
-     data so it executes *after* them (last-in first-out).
+1. Copy-paste this script into a new script tag after the Bitsy source code.
+   It should appear *before* any other mods that handle loading your game
+   data so it executes *after* them (last-in first-out).
 
-NOTE: This uses parentheses "()" instead of curly braces "{}" around function
-      calls because the Bitsy editor's fancy dialog window strips unrecognized
-      curly-brace functions from dialog text. To keep from losing data, write
-      these function calls with parentheses like the examples above.
+NOTE:
+This uses parentheses "()" instead of curly braces "{}" around function
+calls because the Bitsy editor's fancy dialog window strips unrecognized
+curly-brace functions from dialog text. To keep from losing data, write
+these function calls with parentheses like the examples above.
 
-      For full editor integration, you'd *probably* also need to paste this
-      code at the end of the editor's `bitsy.js` file. Untested.
+For full editor integration, you'd *probably* also need to paste this
+code at the end of the editor's `bitsy.js` file. Untested.
 */
 this.hacks = this.hacks || {};
 (function (bitsy) {
@@ -373,12 +370,11 @@ function addDualDialogTag(tag, fn) {
 
 // Implement the dialog functions
 addDualDialogTag('exit', function (environment, parameters) {
-	var exitParams = _getExitParams(parameters);
-	if (!exitParams) {
+	var exit = _getExitParams(parameters);
+	if (!exit) {
 		return;
 	}
-
-	doPlayerExit(exitParams);
+	bitsy.movePlayerThroughExit(exit);
 });
 
 function _getExitParams(parameters) {
@@ -386,33 +382,27 @@ function _getExitParams(parameters) {
 	var roomName = params[0];
 	var x = params[1];
 	var y = params[2];
-	var coordsType = (params[3] || 'exit').toLowerCase();
-	var useSpriteCoords = coordsType === 'sprite';
-	var roomId = getRoom(roomName).id;
+	var transition_effect = params[3];
+	var room = getRoom(roomName).id;
 
 	if (!roomName || x === undefined || y === undefined) {
 		console.warn('{exit/exitNow} was missing parameters! Usage: {exit/exitNow "roomname,x,y"}');
 		return null;
 	}
 
-	if (roomId === undefined) {
+	if (room === undefined) {
 		console.warn("Bad {exit/exitNow} parameter: Room '" + roomName + "' not found!");
 		return null;
 	}
 
 	return {
-		room: roomId,
-		x: Number(x),
-		y: useSpriteCoords ? 15 - Number(y) : Number(y)
+		dest: {
+			room,
+			x: Number(x),
+			y: Number(y),
+		},
+		transition_effect,
 	};
-}
-
-// dest === {room: Room, x: Int, y: Int}
-function doPlayerExit(dest) {
-	bitsy.player().room = dest.room;
-	bitsy.player().x = dest.x;
-	bitsy.player().y = dest.y;
-	bitsy.curRoom = dest.room;
 }
 // End of (exit) dialog function mod
 

--- a/src/exit-from-dialog.js
+++ b/src/exit-from-dialog.js
@@ -3,8 +3,8 @@
 @file exit-from-dialog
 @summary exit to another room from dialog, including conditionals
 @license WTFPL (do WTF you want)
-@version 5.2.2
-@requires Bitsy Version: 4.5, 4.6
+@version 6.0.0
+@requires Bitsy Version: 6.0
 @author @mildmojo
 
 @description
@@ -58,8 +58,7 @@ addDualDialogTag('exit', function (environment, parameters) {
 	if (!exitParams) {
 		return;
 	}
-
-	doPlayerExit(exitParams);
+	bitsy.movePlayerThroughExit({ dest: exitParams });
 });
 
 function _getExitParams(parameters) {
@@ -86,13 +85,5 @@ function _getExitParams(parameters) {
 		x: Number(x),
 		y: useSpriteCoords ? 15 - Number(y) : Number(y)
 	};
-}
-
-// dest === {room: Room, x: Int, y: Int}
-function doPlayerExit(dest) {
-	bitsy.player().room = dest.room;
-	bitsy.player().x = dest.x;
-	bitsy.player().y = dest.y;
-	bitsy.curRoom = dest.room;
 }
 // End of (exit) dialog function mod

--- a/src/exit-from-dialog.js
+++ b/src/exit-from-dialog.js
@@ -18,17 +18,10 @@ Using the (exit) function in any part of a series of dialog will make the
 game exit to the new room after the dialog is finished. Using (exitNow) will
 immediately warp to the new room, but the current dialog will continue.
 
-WARNING: In exit coordinates, the TOP LEFT tile is (0,0). In sprite coordinates,
-         the BOTTOM LEFT tile is (0,0). If you'd like to use sprite coordinates,
-         add the word "sprite" as the fourth parameter to the exit function.
-
 Usage: (exit "<room name>,<x>,<y>")
-       (exit "<room name>,<x>,<y>,sprite")
        (exitNow "<room name>,<x>,<y>")
-       (exitNow "<room name>,<x>,<y>,sprite")
 
 Example: (exit "FinalRoom,8,4")
-         (exitNow "FinalRoom,8,11,sprite")
 
 HOW TO USE:
   1. Copy-paste this script into a new script tag after the Bitsy source code.
@@ -43,7 +36,6 @@ NOTE: This uses parentheses "()" instead of curly braces "{}" around function
       For full editor integration, you'd *probably* also need to paste this
       code at the end of the editor's `bitsy.js` file. Untested.
 */
-'use strict';
 import bitsy from "bitsy";
 import {
 	getRoom
@@ -54,11 +46,11 @@ import {
 
 // Implement the dialog functions
 addDualDialogTag('exit', function (environment, parameters) {
-	var exitParams = _getExitParams(parameters);
-	if (!exitParams) {
+	var exit = _getExitParams(parameters);
+	if (!exit) {
 		return;
 	}
-	bitsy.movePlayerThroughExit({ dest: exitParams });
+	bitsy.movePlayerThroughExit(exit);
 });
 
 function _getExitParams(parameters) {
@@ -66,24 +58,24 @@ function _getExitParams(parameters) {
 	var roomName = params[0];
 	var x = params[1];
 	var y = params[2];
-	var coordsType = (params[3] || 'exit').toLowerCase();
-	var useSpriteCoords = coordsType === 'sprite';
-	var roomId = getRoom(roomName).id;
+	var room = getRoom(roomName).id;
 
 	if (!roomName || x === undefined || y === undefined) {
 		console.warn('{exit/exitNow} was missing parameters! Usage: {exit/exitNow "roomname,x,y"}');
 		return null;
 	}
 
-	if (roomId === undefined) {
+	if (room === undefined) {
 		console.warn("Bad {exit/exitNow} parameter: Room '" + roomName + "' not found!");
 		return null;
 	}
 
 	return {
-		room: roomId,
-		x: Number(x),
-		y: useSpriteCoords ? 15 - Number(y) : Number(y)
+		dest: {
+			room,
+			x: Number(x),
+			y: Number(y),
+		},
 	};
 }
 // End of (exit) dialog function mod

--- a/src/exit-from-dialog.js
+++ b/src/exit-from-dialog.js
@@ -8,8 +8,8 @@
 @author @mildmojo
 
 @description
-Lets you exit to another room from dialog (including inside conditionals). Use
-it to make an invisible sprite that acts as a conditional exit, use it to warp
+Lets you exit to another room from dialog (including inside conditionals).
+Use it to make an invisible sprite that acts as a conditional exit, use it to warp
 somewhere after a conversation, use it to put a guard at your gate who only
 lets you in once you're disguised, use it to require payment before the
 ferryman will take you across the river.
@@ -18,23 +18,27 @@ Using the (exit) function in any part of a series of dialog will make the
 game exit to the new room after the dialog is finished. Using (exitNow) will
 immediately warp to the new room, but the current dialog will continue.
 
-Usage: (exit "<room name>,<x>,<y>")
-       (exitNow "<room name>,<x>,<y>")
+Usage:
+	(exit "<room name>,<x>,<y>,<optional transition_effect>")
+	(exitNow "<room name>,<x>,<y>,<optional transition_effect>")
 
-Example: (exit "FinalRoom,8,4")
+Example:
+	(exit "FinalRoom,8,4")
+	(exit "FinalRoom,8,4,tunnel")
 
 HOW TO USE:
-  1. Copy-paste this script into a new script tag after the Bitsy source code.
-     It should appear *before* any other mods that handle loading your game
-     data so it executes *after* them (last-in first-out).
+1. Copy-paste this script into a new script tag after the Bitsy source code.
+   It should appear *before* any other mods that handle loading your game
+   data so it executes *after* them (last-in first-out).
 
-NOTE: This uses parentheses "()" instead of curly braces "{}" around function
-      calls because the Bitsy editor's fancy dialog window strips unrecognized
-      curly-brace functions from dialog text. To keep from losing data, write
-      these function calls with parentheses like the examples above.
+NOTE:
+This uses parentheses "()" instead of curly braces "{}" around function
+calls because the Bitsy editor's fancy dialog window strips unrecognized
+curly-brace functions from dialog text. To keep from losing data, write
+these function calls with parentheses like the examples above.
 
-      For full editor integration, you'd *probably* also need to paste this
-      code at the end of the editor's `bitsy.js` file. Untested.
+For full editor integration, you'd *probably* also need to paste this
+code at the end of the editor's `bitsy.js` file. Untested.
 */
 import bitsy from "bitsy";
 import {

--- a/src/exit-from-dialog.js
+++ b/src/exit-from-dialog.js
@@ -58,6 +58,7 @@ function _getExitParams(parameters) {
 	var roomName = params[0];
 	var x = params[1];
 	var y = params[2];
+	var transition_effect = params[3];
 	var room = getRoom(roomName).id;
 
 	if (!roomName || x === undefined || y === undefined) {
@@ -76,6 +77,7 @@ function _getExitParams(parameters) {
 			x: Number(x),
 			y: Number(y),
 		},
+		transition_effect,
 	};
 }
 // End of (exit) dialog function mod


### PR DESCRIPTION
- use bitsy's `movePlayerThroughExit` function
- remove coordinate type parameter
- add support for optional transition effect