### PR TITLE
add build script option to specify dependencies as external

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -6,12 +6,12 @@ import rollup from "rollup";
 import nodeResolve from "rollup-plugin-node-resolve";
 import commonjs from "rollup-plugin-commonjs";
 
-export async function buildOne(src = '', plugins = []) {
+export async function buildOne(src = '', plugins = [], externalDeps = {}) {
 	const inputOptions = {
 		input: src,
 		external: [
 			'bitsy'
-		],
+		].concat(Object.keys(externalDeps)),
 		plugins: [
 			nodeResolve(),
 			commonjs()
@@ -20,9 +20,9 @@ export async function buildOne(src = '', plugins = []) {
 
 	const outputOptions = {
 		format: "iife",
-		globals: {
+		globals: Object.assign({
 			bitsy: 'window'
-		},
+		}, externalDeps),
 		name: `hacks.${basename(src, '.js').replace(/\s/g,'_')}`,
 	};
 
@@ -31,7 +31,7 @@ export async function buildOne(src = '', plugins = []) {
 	return output.code;
 }
 
-export async function build(hacks = [], plugins) {
-	const output = await Promise.all(hacks.map(hack => buildOne(hack, plugins)));
+export async function build(hacks = [], plugins, externalDeps) {
+	const output = await Promise.all(hacks.map(hack => buildOne(hack, plugins, externalDeps)));
 	return output;
 }


### PR DESCRIPTION
this will allow to specify large dependencies like babylon as external to reduce build time, super useful for 3d hack. i'm preparing a pull request for bitsy-boilerplate too that makes use of this and writes babylon library separately to the ouput html instead of processing it with rollup (this works as expected and reduces build time from 17 to 2-3 seconds at least with my hardware)