### PR TITLE
Bug/tracery modifiers

### DIFF
--- a/dist/tracery-processing.js
+++ b/dist/tracery-processing.js
@@ -3,7 +3,7 @@
 @file tracery processing
 @summary process all dialog text with a tracery grammar
 @license MIT
-@version 2.0.3
+@version 3.0.0
 @author Sean S. LeBlanc
 
 @description
@@ -43,7 +43,11 @@ this.hacks = this.hacks || {};
 (function (exports, bitsy) {
 'use strict';
 var hackOptions = {
-	// put your grammar entries here
+	grammar: {
+		// put your grammar entries here
+	},
+	// modifiers to include (if this is not provided, the default tracery-provided modifiers like `.capitalize` are used)
+	modifiers: undefined,
 };
 
 bitsy = bitsy && bitsy.hasOwnProperty('default') ? bitsy['default'] : bitsy;
@@ -1084,7 +1088,13 @@ function _reinitEngine() {
 
 
 
-var bitsyGrammar = tracery_1.createGrammar(hackOptions);
+var bitsyGrammar;
+
+before('onready', function () {
+	bitsyGrammar = tracery_1.createGrammar(hackOptions.grammar);
+	bitsyGrammar.addModifiers(hackOptions.modifiers || tracery_1.baseEngModifiers);
+});
+
 before('startDialog', function (dialogStr) {
 	return [bitsyGrammar.flatten(dialogStr)];
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitsy/hecks",
-  "version": "7.7.1",
+  "version": "8.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"hacks"
 	],
 	"main": "index.mjs",
-	"version": "7.7.1",
+	"version": "8.0.0",
 	"scripts": {
 		"build": "rollup -c",
 		"test": "jest --runInBand",

--- a/src/tracery processing.js
+++ b/src/tracery processing.js
@@ -3,7 +3,7 @@
 @file tracery processing
 @summary process all dialog text with a tracery grammar
 @license MIT
-@version 2.0.3
+@version 3.0.0
 @author Sean S. LeBlanc
 
 @description

--- a/src/tracery processing.js
+++ b/src/tracery processing.js
@@ -48,12 +48,15 @@ export var hackOptions = {
 	grammar: {
 		// put your grammar entries here
 	},
+	// modifiers to include (if this is not provided, the default tracery-provided modifiers like `.capitalize` are used)
+	modifiers: undefined,
 };
 
 var bitsyGrammar;
 
 before('onready', function () {
 	bitsyGrammar = tracery.createGrammar(hackOptions.grammar);
+	bitsyGrammar.addModifiers(hackOptions.modifiers || tracery.baseEngModifiers);
 });
 
 before('startDialog', function (dialogStr) {

--- a/src/tracery processing.js
+++ b/src/tracery processing.js
@@ -45,10 +45,17 @@ import {
 } from './helpers/kitsy-script-toolkit';
 
 export var hackOptions = {
-	// put your grammar entries here
+	grammar: {
+		// put your grammar entries here
+	},
 };
 
-var bitsyGrammar = tracery.createGrammar(hackOptions);
+var bitsyGrammar;
+
+before('onready', function () {
+	bitsyGrammar = tracery.createGrammar(hackOptions.grammar);
+});
+
 before('startDialog', function (dialogStr) {
 	return [bitsyGrammar.flatten(dialogStr)];
 });


### PR DESCRIPTION
fixes issues with tracery hack:

- initialization was run at top-level, which makes use as module more difficult; init happens before `onready` now
- fixed lack of modifiers and updated `hackOptions` to support customizing them (required changing `hackOptions` format to have a `grammar` option instead of just using the object itself