### PR TITLE
Follower updates

### DIFF
--- a/dist/follower.js
+++ b/dist/follower.js
@@ -17,6 +17,8 @@ Usage:
 	(followerCollision "true/false")
 	(followerDelay "frames")
 	(followerDelayNow "frames")
+	(followerSync)
+	(followerSyncNow)
 
 Examples:
 	(follower "a") - the sprite with the id "a" starts following
@@ -27,6 +29,7 @@ Examples:
 	(followerDelay "0") - sets follower to move immediately after player
 	(followerDelay "200") - sets follower to move at normal speed
 	(followerDelay "1000") - sets follower to move once per second
+	(followerSync) - moves the follower on top of the player
 
 
 Known issues:
@@ -35,6 +38,10 @@ Known issues:
 - When collision is enabled, it's possible for the player to get stuck
   between walls and their follower. Make sure to avoid single-tile width
   spaces when using this (or design with that restriction in mind!)
+- The follower will only automatically follow the player through
+  natural placed exits; if combining this with exit-from-dialog,
+  you can use the (followerSync)/(followerSyncNow) commands
+  to keep them together
 
 HOW TO USE:
 1. Copy-paste this script into a script tag after the bitsy source
@@ -462,6 +469,15 @@ addDialogTag('followerCollision', function (environment, parameters) {
 });
 addDualDialogTag('followerDelay', function (environment, parameters) {
 	hackOptions.delay = parseInt(parameters[0], 10);
+});
+addDualDialogTag('followerSync', function () {
+	if (follower) {
+		var player = bitsy.player();
+		follower.room = player.room;
+		follower.x = player.x;
+		follower.y = player.y;
+		follower.walkingPath.length = 0;
+	}
 });
 
 before('moveSprites', function () {

--- a/dist/follower.js
+++ b/dist/follower.js
@@ -3,23 +3,43 @@
 @file follower
 @summary makes a single sprite follow the player
 @license MIT
-@version 2.2.0
+@version 3.0.0
 @author Sean S. LeBlanc
 
 @description
 Makes a single sprite follow the player.
-Bitsy has a "walkingPath" built into the sprite system (I think this is a hold-over from the old pathfinding mouse controls).
-Paths can be assigned to any sprite to create different AI behaviours.
+The follower can optionally collide with the player,
+and can be changed at runtime with dialog commands.
 
-Includes an optional feature which filters the follower out of collisions.
+Usage:
+	(follower "followerNameOrId")
+	(followerNow "followerNameOrId")
+	(followerCollision "true/false")
+	(followerDelay "frames")
+	(followerDelayNow "frames")
+
+Examples:
+	(follower "a") - the sprite with the id "a" starts following
+	(follower "my follower") - the sprite with the name "my follower" starts following
+	(follower) - stops a current follower
+	(followerCollision "true") - enables follower collision
+	(followerCollision "false") - disables follower collision
+	(followerDelay "0") - sets follower to move immediately after player
+	(followerDelay "200") - sets follower to move at normal speed
+	(followerDelay "1000") - sets follower to move once per second
+
 
 Known issues:
-- if the player uses an exit that puts them on top of another exit, the follower walks through the second exit.
-- the follower will warp to the player on the first movement. This can be avoided by placing them next to the player in bitsy.
+- Followers will warp to the player on their first movement.
+  This can be avoided by placing them next to or on the same tile as the player.
+- When collision is enabled, it's possible for the player to get stuck
+  between walls and their follower. Make sure to avoid single-tile width
+  spaces when using this (or design with that restriction in mind!)
 
 HOW TO USE:
 1. Copy-paste this script into a script tag after the bitsy source
-2. Edit `follower` to your intended sprite
+2. Edit hackOptions below to set up an initial follower
+3. Use dialog commands as needed
 */
 this.hacks = this.hacks || {};
 (function (exports, bitsy) {
@@ -27,6 +47,7 @@ this.hacks = this.hacks || {};
 var hackOptions = {
 	allowFollowerCollision: false, // if true, the player can walk into the follower and talk to them (possible to get stuck this way)
 	follower: 'a', // id or name of sprite to be the follower
+	delay: 200, // delay between each follower step (0 is immediate, 400 is twice as slow as normal)
 };
 
 bitsy = bitsy && bitsy.hasOwnProperty('default') ? bitsy['default'] : bitsy;
@@ -121,6 +142,25 @@ HOW TO USE:
   For more info, see the documentation at:
   https://github.com/seleb/bitsy-hacks/wiki/Coding-with-kitsy
 */
+
+
+// Ex: inject(/(names.sprite.set\( name, id \);)/, '$1console.dir(names)');
+function inject$1(searchRegex, replaceString) {
+	var kitsy = kitsyInit();
+	kitsy.queuedInjectScripts.push({
+		searchRegex: searchRegex,
+		replaceString: replaceString
+	});
+}
+
+// Ex: before('load_game', function run() { alert('Loading!'); });
+//     before('show_text', function run(text) { return text.toUpperCase(); });
+//     before('show_text', function run(text, done) { done(text.toUpperCase()); });
+function before(targetFuncName, beforeFn) {
+	var kitsy = kitsyInit();
+	kitsy.queuedBeforeScripts[targetFuncName] = kitsy.queuedBeforeScripts[targetFuncName] || [];
+	kitsy.queuedBeforeScripts[targetFuncName].push(beforeFn);
+}
 
 // Ex: after('load_game', function run() { alert('Loaded!'); });
 function after(targetFuncName, afterFn) {
@@ -236,50 +276,147 @@ function _reinitEngine() {
 	bitsy.dialogBuffer = bitsy.dialogModule.CreateBuffer();
 }
 
+// Rewrite custom functions' parentheses to curly braces for Bitsy's
+// interpreter. Unescape escaped parentheticals, too.
+function convertDialogTags(input, tag) {
+	return input
+		.replace(new RegExp('\\\\?\\((' + tag + '(\\s+(".+?"|.+?))?)\\\\?\\)', 'g'), function (match, group) {
+			if (match.substr(0, 1) === '\\') {
+				return '(' + group + ')'; // Rewrite \(tag "..."|...\) to (tag "..."|...)
+			}
+			return '{' + group + '}'; // Rewrite (tag "..."|...) to {tag "..."|...}
+		});
+}
+
+
+function addDialogFunction(tag, fn) {
+	var kitsy = kitsyInit();
+	kitsy.dialogFunctions = kitsy.dialogFunctions || {};
+	if (kitsy.dialogFunctions[tag]) {
+		throw new Error('The dialog function "' + tag + '" already exists.');
+	}
+
+	// Hook into game load and rewrite custom functions in game data to Bitsy format.
+	before('parseWorld', function (game_data) {
+		return [convertDialogTags(game_data, tag)];
+	});
+
+	kitsy.dialogFunctions[tag] = fn;
+}
+
+/**
+ * Adds a custom dialog tag which executes the provided function.
+ * For ease-of-use with the bitsy editor, tags can be written as
+ * (tagname "parameters") in addition to the standard {tagname "parameters"}
+ * 
+ * Function is executed immediately when the tag is reached.
+ *
+ * @param {string}   tag Name of tag
+ * @param {Function} fn  Function to execute, with signature `function(environment, parameters, onReturn){}`
+ *                       environment: provides access to SetVariable/GetVariable (among other things, see Environment in the bitsy source for more info)
+ *                       parameters: array containing parameters as string in first element (i.e. `parameters[0]`)
+ *                       onReturn: function to call with return value (just call `onReturn(null);` at the end of your function if your tag doesn't interact with the logic system)
+ */
+function addDialogTag(tag, fn) {
+	addDialogFunction(tag, fn);
+	inject$1(
+		/(var functionMap = new Map\(\);)/,
+		'$1functionMap.set("' + tag + '", kitsy.dialogFunctions.' + tag + ');'
+	);
+}
+
+/**
+ * Adds a custom dialog tag which executes the provided function.
+ * For ease-of-use with the bitsy editor, tags can be written as
+ * (tagname "parameters") in addition to the standard {tagname "parameters"}
+ * 
+ * Function is executed after the dialog box.
+ *
+ * @param {string}   tag Name of tag
+ * @param {Function} fn  Function to execute, with signature `function(environment, parameters){}`
+ *                       environment: provides access to SetVariable/GetVariable (among other things, see Environment in the bitsy source for more info)
+ *                       parameters: array containing parameters as string in first element (i.e. `parameters[0]`)
+ */
+function addDeferredDialogTag(tag, fn) {
+	addDialogFunction(tag, fn);
+	bitsy.kitsy.deferredDialogFunctions = bitsy.kitsy.deferredDialogFunctions || {};
+	var deferred = bitsy.kitsy.deferredDialogFunctions[tag] = [];
+	inject$1(
+		/(var functionMap = new Map\(\);)/,
+		'$1functionMap.set("' + tag + '", function(e, p, o){ kitsy.deferredDialogFunctions.' + tag + '.push({e:e,p:p}); o(null); });'
+	);
+	// Hook into the dialog finish event and execute the actual function
+	after('onExitDialog', function () {
+		while (deferred.length) {
+			var args = deferred.shift();
+			bitsy.kitsy.dialogFunctions[tag](args.e, args.p, args.o);
+		}
+	});
+	// Hook into the game reset and make sure data gets cleared
+	after('clearGameData', function () {
+		deferred.length = 0;
+	});
+}
+
+/**
+ * Adds two custom dialog tags which execute the provided function,
+ * one with the provided tagname executed after the dialog box,
+ * and one suffixed with 'Now' executed immediately when the tag is reached.
+ *
+ * i.e. helper for the (exit)/(exitNow) pattern.
+ *
+ * @param {string}   tag Name of tag
+ * @param {Function} fn  Function to execute, with signature `function(environment, parameters){}`
+ *                       environment: provides access to SetVariable/GetVariable (among other things, see Environment in the bitsy source for more info)
+ *                       parameters: array containing parameters as string in first element (i.e. `parameters[0]`)
+ */
+function addDualDialogTag(tag, fn) {
+	addDialogTag(tag + 'Now', function (environment, parameters, onReturn) {
+		fn(environment, parameters);
+		onReturn(null);
+	});
+	addDeferredDialogTag(tag, fn);
+}
+
 
 
 
 
 var follower;
+
+function setFollower(followerName) {
+	follower = getImage(followerName, bitsy.sprite);
+}
+
 after('startExportedGame', function () {
-	follower = getImage(hackOptions.follower, bitsy.sprite);
+	setFollower(hackOptions.follower);
 
 	// remove + add player to sprite list to force rendering them on top of follower
 	var p = bitsy.sprite[bitsy.playerId];
 	delete bitsy.sprite[bitsy.playerId];
 	bitsy.sprite[bitsy.playerId] = p;
-
-	lastRoom = bitsy.player().room;
 });
 
-var lastRoom;
 after('onPlayerMoved', function () {
-	// detect room change
-	if (lastRoom !== bitsy.player().room) {
-		// on room change, warp to player
-		lastRoom = follower.room = bitsy.player().room;
-		follower.x = bitsy.player().x;
-		follower.y = bitsy.player().y;
-		follower.walkingPath.length = 0;
-	} else {
-		var step = {
-			x: bitsy.player().x,
-			y: bitsy.player().y,
-		};
-		switch (bitsy.curPlayerDirection) {
-		case bitsy.Direction.Up:
-			step.y += 1;
-			break;
-		case bitsy.Direction.Down:
-			step.y -= 1;
-			break;
-		case bitsy.Direction.Left:
-			step.x += 1;
-			break;
-		case bitsy.Direction.Right:
-			step.x -= 1;
-			break;
-		}
+	var step = {
+		x: bitsy.player().x,
+		y: bitsy.player().y,
+	};
+	switch (bitsy.curPlayerDirection) {
+	case bitsy.Direction.Up:
+		step.y += 1;
+		break;
+	case bitsy.Direction.Down:
+		step.y -= 1;
+		break;
+	case bitsy.Direction.Left:
+		step.x += 1;
+		break;
+	case bitsy.Direction.Right:
+		step.x -= 1;
+		break;
+	}
+	if (follower) {
 		follower.walkingPath.push(step);
 	}
 });
@@ -316,6 +453,21 @@ bitsy.getSpriteDown = function () {
 	}
 	return originalGetSpriteDown();
 };
+
+addDualDialogTag('follower', function (environment, parameters) {
+	setFollower(parameters[0]);
+});
+addDialogTag('followerCollision', function (environment, parameters) {
+	hackOptions.allowFollowerCollision = parameters[0] !== 'false';
+});
+addDualDialogTag('followerDelay', function (environment, parameters) {
+	hackOptions.delay = parseInt(parameters[0], 10);
+});
+
+before('moveSprites', function () {
+	bitsy.moveCounter -= bitsy.deltaTime; // cancel out default movement delay
+	bitsy.moveCounter += bitsy.deltaTime * (200 / hackOptions.delay); // apply movement delay from options
+});
 
 exports.hackOptions = hackOptions;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitsy/hecks",
-  "version": "8.4.0",
+  "version": "9.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"hacks"
 	],
 	"main": "index.mjs",
-	"version": "8.4.0",
+	"version": "9.0.0",
 	"scripts": {
 		"build": "rollup -c",
 		"test": "jest --runInBand",

--- a/src/follower.js
+++ b/src/follower.js
@@ -3,7 +3,7 @@
 @file follower
 @summary makes a single sprite follow the player
 @license MIT
-@version 2.2.0
+@version 3.0.0
 @author Sean S. LeBlanc
 
 @description

--- a/src/follower.js
+++ b/src/follower.js
@@ -29,11 +29,13 @@ import {
 	after,
 	addDualDialogTag,
 	addDialogTag,
+	inject,
 } from './helpers/kitsy-script-toolkit';
 
 export var hackOptions = {
 	allowFollowerCollision: false, // if true, the player can walk into the follower and talk to them (possible to get stuck this way)
 	follower: 'a', // id or name of sprite to be the follower
+	delay: 200, // delay between each follower step
 };
 
 var follower;
@@ -115,3 +117,5 @@ addDualDialogTag('follower', function (environment, parameters) {
 addDialogTag('followerCollision', function (environment, parameters) {
 	hackOptions.allowFollowerCollision = parameters[0] !== 'false';
 });
+
+inject(/(var moveTime = )200;/, '$1' + hackOptions.delay + ';');

--- a/src/follower.js
+++ b/src/follower.js
@@ -44,13 +44,13 @@ import {
 	after,
 	addDualDialogTag,
 	addDialogTag,
-	inject,
+	before,
 } from './helpers/kitsy-script-toolkit';
 
 export var hackOptions = {
 	allowFollowerCollision: false, // if true, the player can walk into the follower and talk to them (possible to get stuck this way)
 	follower: 'a', // id or name of sprite to be the follower
-	delay: 200, // delay between each follower step
+	delay: 200, // delay between each follower step (0 is immediate, 400 is twice as slow as normal)
 };
 
 var follower;
@@ -134,4 +134,7 @@ addDialogTag('followerCollision', function (environment, parameters) {
 	hackOptions.allowFollowerCollision = parameters[0] !== 'false';
 });
 
-inject(/(var moveTime = )200;/, '$1' + hackOptions.delay + ';');
+before('moveSprites', function () {
+	bitsy.moveCounter -= bitsy.deltaTime; // cancel out default movement delay
+	bitsy.moveCounter += bitsy.deltaTime * (200 / hackOptions.delay); // apply movement delay from options
+});

--- a/src/follower.js
+++ b/src/follower.js
@@ -42,42 +42,30 @@ after('startExportedGame', function () {
 	var p = bitsy.sprite[bitsy.playerId];
 	delete bitsy.sprite[bitsy.playerId];
 	bitsy.sprite[bitsy.playerId] = p;
-
-	lastRoom = bitsy.player().room;
 });
 
-var lastRoom;
 after('onPlayerMoved', function () {
-	// detect room change
-	if (lastRoom !== bitsy.player().room) {
-		// on room change, warp to player
-		lastRoom = follower.room = bitsy.player().room;
-		follower.x = bitsy.player().x;
-		follower.y = bitsy.player().y;
-		follower.walkingPath.length = 0;
-	} else {
-		var step = {
-			x: bitsy.player().x,
-			y: bitsy.player().y,
-		};
-		switch (bitsy.curPlayerDirection) {
-		case bitsy.Direction.Up:
-			step.y += 1;
-			break;
-		case bitsy.Direction.Down:
-			step.y -= 1;
-			break;
-		case bitsy.Direction.Left:
-			step.x += 1;
-			break;
-		case bitsy.Direction.Right:
-			step.x -= 1;
-			break;
-		default:
-			break;
-		}
-		follower.walkingPath.push(step);
+	var step = {
+		x: bitsy.player().x,
+		y: bitsy.player().y,
+	};
+	switch (bitsy.curPlayerDirection) {
+	case bitsy.Direction.Up:
+		step.y += 1;
+		break;
+	case bitsy.Direction.Down:
+		step.y -= 1;
+		break;
+	case bitsy.Direction.Left:
+		step.x += 1;
+		break;
+	case bitsy.Direction.Right:
+		step.x -= 1;
+		break;
+	default:
+		break;
 	}
+	follower.walkingPath.push(step);
 });
 
 function filterFollowing(id) {

--- a/src/follower.js
+++ b/src/follower.js
@@ -15,6 +15,8 @@ Usage:
 	(follower "followerNameOrId")
 	(followerNow "followerNameOrId")
 	(followerCollision "true/false")
+	(followerDelay "frames")
+	(followerDelayNow "frames")
 
 Examples:
 	(follower "a") - the sprite with the id "a" starts following
@@ -22,6 +24,9 @@ Examples:
 	(follower) - stops a current follower
 	(followerCollision "true") - enables follower collision
 	(followerCollision "false") - disables follower collision
+	(followerDelay "0") - sets follower to move immediately after player
+	(followerDelay "200") - sets follower to move at normal speed
+	(followerDelay "1000") - sets follower to move once per second
 
 
 Known issues:
@@ -132,6 +137,9 @@ addDualDialogTag('follower', function (environment, parameters) {
 });
 addDialogTag('followerCollision', function (environment, parameters) {
 	hackOptions.allowFollowerCollision = parameters[0] !== 'false';
+});
+addDualDialogTag('followerDelay', function (environment, parameters) {
+	hackOptions.delay = parseInt(parameters[0], 10);
 });
 
 before('moveSprites', function () {

--- a/src/follower.js
+++ b/src/follower.js
@@ -73,6 +73,7 @@ after('onPlayerMoved', function () {
 		break;
 	default:
 		break;
+	}
 	if (follower) {
 		follower.walkingPath.push(step);
 	}

--- a/src/follower.js
+++ b/src/follower.js
@@ -17,6 +17,8 @@ Usage:
 	(followerCollision "true/false")
 	(followerDelay "frames")
 	(followerDelayNow "frames")
+	(followerSync)
+	(followerSyncNow)
 
 Examples:
 	(follower "a") - the sprite with the id "a" starts following
@@ -27,6 +29,7 @@ Examples:
 	(followerDelay "0") - sets follower to move immediately after player
 	(followerDelay "200") - sets follower to move at normal speed
 	(followerDelay "1000") - sets follower to move once per second
+	(followerSync) - moves the follower on top of the player
 
 
 Known issues:
@@ -35,6 +38,10 @@ Known issues:
 - When collision is enabled, it's possible for the player to get stuck
   between walls and their follower. Make sure to avoid single-tile width
   spaces when using this (or design with that restriction in mind!)
+- The follower will only automatically follow the player through
+  natural placed exits; if combining this with exit-from-dialog,
+  you can use the (followerSync)/(followerSyncNow) commands
+  to keep them together
 
 HOW TO USE:
 1. Copy-paste this script into a script tag after the bitsy source
@@ -140,6 +147,15 @@ addDialogTag('followerCollision', function (environment, parameters) {
 });
 addDualDialogTag('followerDelay', function (environment, parameters) {
 	hackOptions.delay = parseInt(parameters[0], 10);
+});
+addDualDialogTag('followerSync', function () {
+	if (follower) {
+		var player = bitsy.player();
+		follower.room = player.room;
+		follower.x = player.x;
+		follower.y = player.y;
+		follower.walkingPath.length = 0;
+	}
 });
 
 before('moveSprites', function () {

--- a/src/follower.js
+++ b/src/follower.js
@@ -27,6 +27,8 @@ import {
 } from './helpers/utils';
 import {
 	after,
+	addDualDialogTag,
+	addDialogTag,
 } from './helpers/kitsy-script-toolkit';
 
 export var hackOptions = {
@@ -35,8 +37,13 @@ export var hackOptions = {
 };
 
 var follower;
+
+function setFollower(followerName) {
+	follower = getImage(followerName, bitsy.sprite);
+}
+
 after('startExportedGame', function () {
-	follower = getImage(hackOptions.follower, bitsy.sprite);
+	setFollower(hackOptions.follower);
 
 	// remove + add player to sprite list to force rendering them on top of follower
 	var p = bitsy.sprite[bitsy.playerId];
@@ -64,8 +71,9 @@ after('onPlayerMoved', function () {
 		break;
 	default:
 		break;
+	if (follower) {
+		follower.walkingPath.push(step);
 	}
-	follower.walkingPath.push(step);
 });
 
 function filterFollowing(id) {
@@ -100,3 +108,10 @@ bitsy.getSpriteDown = function () {
 	}
 	return originalGetSpriteDown();
 };
+
+addDualDialogTag('follower', function (environment, parameters) {
+	setFollower(parameters[0]);
+});
+addDialogTag('followerCollision', function (environment, parameters) {
+	hackOptions.allowFollowerCollision = parameters[0] !== 'false';
+});

--- a/src/follower.js
+++ b/src/follower.js
@@ -8,18 +8,33 @@
 
 @description
 Makes a single sprite follow the player.
-Bitsy has a "walkingPath" built into the sprite system (I think this is a hold-over from the old pathfinding mouse controls).
-Paths can be assigned to any sprite to create different AI behaviours.
+The follower can optionally collide with the player,
+and can be changed at runtime with dialog commands.
 
-Includes an optional feature which filters the follower out of collisions.
+Usage:
+	(follower "followerNameOrId")
+	(followerNow "followerNameOrId")
+	(followerCollision "true/false")
+
+Examples:
+	(follower "a") - the sprite with the id "a" starts following
+	(follower "my follower") - the sprite with the name "my follower" starts following
+	(follower) - stops a current follower
+	(followerCollision "true") - enables follower collision
+	(followerCollision "false") - disables follower collision
+
 
 Known issues:
-- if the player uses an exit that puts them on top of another exit, the follower walks through the second exit.
-- the follower will warp to the player on the first movement. This can be avoided by placing them next to the player in bitsy.
+- Followers will warp to the player on their first movement.
+  This can be avoided by placing them next to or on the same tile as the player.
+- When collision is enabled, it's possible for the player to get stuck
+  between walls and their follower. Make sure to avoid single-tile width
+  spaces when using this (or design with that restriction in mind!)
 
 HOW TO USE:
 1. Copy-paste this script into a script tag after the bitsy source
-2. Edit `follower` to your intended sprite
+2. Edit hackOptions below to set up an initial follower
+3. Use dialog commands as needed
 */
 import bitsy from 'bitsy';
 import {


### PR DESCRIPTION
- fixes issue where going through bi-directional exits with a follower causes the follower to desync and walk around in the wrong room (thanks @ducklingsmith for debugging this)
- adds delay option
- adds dialog commands to change follower, collision, delay, and sync at runtime

note that the teleport code which was removed due to the bug was originally intended to fix issues where followers didn't follow players through `exit-from-dialog` (since `walkingPath` relies on the natural exit behaviour and moves sprites through them automatically). to cover for this, the `followerSync`/`followerSyncNow` commands were added