### PR TITLE
Pull Request for Edit Room from Dialog, Palette Map, and Textbox Styler hackpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A collection of re-usable scripts for [Adam Le Doux](https://twitter.com/adamled
 - 🖼 [dynamic background](/dist/dynamic-background.js): HTML background matching bitsy background
 - 📝 [edit dialog from dialog](/dist/edit-dialog-from-dialog.js): edit dialog from dialog (yes really)
 - 🖌 [edit image from dialog](/dist/edit-image-from-dialog.js): edit sprites, items, and tiles from dialog
+- 🏠 [edit room from dialog](/dist/edit-room-from-dialog.js): modify the content of a room from dialog
 - 🔚 [end-from-dialog](/dist/end-from-dialog.js): trigger an ending from dialog, including narration text
 - 🚪 [exit-from-dialog](/dist/exit-from-dialog.js): exit to another room from dialog, including conditionals
 - 🛰 [external-game-data](/dist/external-game-data.js): separate Bitsy game data from your (modded) HTML for easier development
@@ -42,6 +43,7 @@ A collection of re-usable scripts for [Adam Le Doux](https://twitter.com/adamled
 - 📎 [noclip](/dist/noclip.js): walk through wall tiles, sprites, items, exits, and endings
 - 🔄 [online](/dist/online.js): multiplayer bitsy
 - ⬛ [opaque tiles](/dist/opaque-tiles.js): tiles which hide the player
+- 🎨 [palette maps](/dist/palette-maps.js): allows color pallettes to be defined on a tile-by-tile basis
 - 📃 [paragraph-break](/dist/paragraph-break.js): Adds paragraph breaks to the dialogue parser
 - ⏳ [permanent items](/dist/permanent-items.js): prevent some items from being picked up
 - ➡ [push sprites](/dist/push-sprites.js): sokoban-style sprite pushing
@@ -51,6 +53,7 @@ A collection of re-usable scripts for [Adam Le Doux](https://twitter.com/adamled
 - 🛑 [solid items](/dist/solid-items.js): treat some items like sprites that can be placed multiple times
 - ⏱️ [stopwatch](/dist/stopwatch.js): time player actions
 - 🗣 [text-to-speech](/dist/text-to-speech.js): text-to-speech for bitsy dialog
+- 📐 [textbox styler](/dist/textbox-styler.js): null
 - 🏰 [tracery processing](/dist/tracery-processing.js): process all dialog text with a tracery grammar
 - 🎞 [transitions](/dist/transitions.js): customizable WebGL transitions
 - 👁️‍🗨️ [transparent dialog](/dist/transparent-dialog.js): makes the dialog box have a transparent background

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ A collection of re-usable scripts for [Adam Le Doux](https://twitter.com/adamled
 - 🛑 [solid items](/dist/solid-items.js): treat some items like sprites that can be placed multiple times
 - ⏱️ [stopwatch](/dist/stopwatch.js): time player actions
 - 🗣 [text-to-speech](/dist/text-to-speech.js): text-to-speech for bitsy dialog
-- 📐 [textbox styler](/dist/textbox-styler.js): null
+- 📐 [textbox styler](/dist/textbox-styler.js): customize the style and properties of the textbox
 - 🏰 [tracery processing](/dist/tracery-processing.js): process all dialog text with a tracery grammar
 - 🎞 [transitions](/dist/transitions.js): customizable WebGL transitions
 - 👁️‍🗨️ [transparent dialog](/dist/transparent-dialog.js): makes the dialog box have a transparent background

--- a/dist/edit-room-from-dialog.js
+++ b/dist/edit-room-from-dialog.js
@@ -1,0 +1,1558 @@
+/**
+🏠
+@file edit room from dialog
+@summary modify the content of a room from dialog
+@license MIT
+@version 1.0.0
+@requires Bitsy Version: 6.1
+@author Dana Holdampf
+
+@description
+This hack allows you to add, remove, or reposition tiles, sprites, and items.
+
+HOW TO USE:
+1. Copy-paste this script into a script tag after the bitsy source
+2. Use the following dialog tags to edit a room's tiles, sprites, or items
+
+-- DRAW DIALOG TAG REFERENCE -----------------------------------
+
+{draw "type, source, x, y, room"}
+{drawNow "type, source, x, y, room"}
+{drawBox "type, source, x1, y1, x2, y2 room"}
+{drawBoxNow "type, source, x1, y1, x2, y2 room"}
+{drawAll "type, source, room"}
+{drawAllNow "type, source, room"}
+
+Information:
+- "draw" creates a tile, item, or sprite at a location in a room. Can be a fixed position, or relative to the player.
+- "drawBox" is as above, but draws tiles, items, or sprites in a box/line, defined by a top left and bottom right corner.
+- "drawAll" is as above, but affects an entire room.
+- Adding "Now" causes it to draw immediately, rather than waiting until the dialog ends.
+
+Parameters:
+- type:		Type of room contents to draw (TIL, ITM, or SPR)
+			Tile (TIL): Each location can have only one Tile. Drawing over an existing tile replaces it.
+			Item (ITM): Multiple items can exist in one spot, but only the most recent item is picked up.
+			Sprite (SPR): Only one copy of each Sprite can exist at a time; redrawing a sprite moves it.
+- source:	The ID (number/letter) of the tile, item, or sprite to draw.
+- x, y:		The x and y coordinates you want to draw at, from 0-15.
+- x1, y1:	(For drawBox only) The x and y coordinates of the top left tile you want to draw on, from 0-15.
+- x2, y2:	(For drawBox only) The x and y coordinates of the bottom right tile you want to draw on, from 0-15.
+			Put + or - before any coordinate to draw relative to the player's current position. (ex. +10, -2, etc.).
+			Leave any coordinate blank (or use +0) to use the player's current X (or Y) position. (If blank, still add commas)
+- room:		The ID (number/letter) of the room you're drawing in. (Refer to Game Data tab for Room IDs)
+			Leave blank to default to modifying the room the player is currently in.
+
+-- ERASE DIALOG TAG REFERENCE ----------------------------------
+
+{erase "type, target, x, y, room"}
+{eraseNow "type, target, x, y, room"}
+{eraseBox "type, target, x1, y1, x2, y2 room"}
+{eraseBoxNow "type, target, x1, y1, x2, y2 room"}
+{eraseAll "type, target, room"}
+{eraseAllNow "type, target, room"}
+
+Information:
+- "erase" Removes tiles, items, or sprites at a location in a room. Can be a fixed position, or relative to the player.
+- "eraseBox" is as above, but erases tiles, items, or sprites in a box/line, defined by a top left and bottom right corner.
+- "eraseAll" is as above, but affects an entire room.
+- Adding "Now" causes it to erase immediately, rather than waiting until the dialog ends.
+
+Parameters:
+- type:		Type of room contents to erase (ANY, TIL, ITM, or SPR)
+			Anything (ANY): Erasing anything will target all valid Tiles, Items, and Sprites.
+			Tile (TIL): Erasing a Tile causes that location to be empty and walkable.
+			Item (ITM): Erasing an Item affects all valid target items, even if there are more than one.
+			Sprite (SPR): Erasing a Sprite removes it from a room, but it will remember dialog progress, etc.
+			Leaving this blank will default to targeting ANY. (If blank, still include commas)
+- target:	The ID (number/letter) of the tile, item, or sprite to erase. Other objects will not be erased.
+			Leave this blank, or set this to "ANY", to target all tiles, items, and/or sprites. (If blank, still include commas)
+- x, y:		The x and y coordinates you want to erase at, from 0-15.
+- x1, y1:	(For eraseBox only) The x and y coordinates of the top left tile you want to erase at, from 0-15.
+- x2, y2:	(For eraseBox only) The x and y coordinates of the bottom right tile you want to erase at, from 0-15.
+			Leave X (or Y) blank to use the player's current X (or Y) position. (If blank, still include commas)
+			Put + or - before the number to erase relative to the player's current position. (ex. +10, -2, etc.).
+- room:		The ID (number/letter) of the room you're erasing in. (Refer to Game Data tab for Room IDs)
+			Leave blank to default to modifying the room the player is currently in.
+
+-- REPLACE DIALOG TAG REFERENCE --------------------------------
+
+{replace "targetType, targetId, newType, newId, x, y, room"}
+{replaceNow "targetType, targetId, newType, newId, x, y, room"}
+{replaceBox "targetType, targetId, newType, newId, x1, y1, x2, y2 room"}
+{replaceBoxNow "targetType, targetId, newType, newId, x1, y1, x2, y2 room"}
+{replaceAll "targetType, targetId, newType, newId, room"}
+{replaceAllNow "targetType, targetId, newType, newId, room"}
+
+Information:
+- "replace" Combines erase and draw. Removes tiles, items, or sprites at a location in a room, and replaces each with something new.
+- "replaceBox" is as above, but replaces tiles, items, or sprites in a box/line, defined by a top left and bottom right corner.
+- "replaceAll" is as above, but affects an entire room.
+- Adding "Now" causes it to erase immediately, rather than waiting until the dialog ends.
+
+Parameters:
+- targetType:	Type of room contents to target for replacing (ANY, TIL, ITM, or SPR).
+				Anything (ANY): Targetting anything will target all valid Tiles, Items, and Sprites.
+				Tile (TIL): Replacing a Tile will remove it, leaving behind walkable space.
+				Item (ITM): Replacing an Item affects all valid items, even if there are more than one.
+				Sprite (SPR): Replacing a Sprite removes it from a room, but it will remember dialog progress, etc.
+				Leaving this blank will default to targeting ANY. (If blank, still include commas)
+- targetId:		The ID (number/letter) of the tile, item, or sprite to replace. Other objects will not be replaced.
+				Leave this blank, or set this to "ANY", to target all tiles, items, and/or sprites. (If blank, still include commas)
+- newType:		As above, but defines the type of room contents to replace the target with (TIL, ITM, or SPR).
+				Note: This must be defined, and cannot be left blank.
+- newId:		As above, but defines the ID (number/letter) of the tile, item, or sprite to replace the target with.
+				Note: This must be defined, and cannot be left blank.
+- x, y:			The x and y coordinates you want to replace at, from 0-15.
+- x1, y1:		(For replaceBox only) The x and y coordinates of the top left tile you want to replace at, from 0-15.
+- x2, y2:		(For replaceBox only) The x and y coordinates of the bottom right tile you want to replace at, from 0-15.
+				Leave X (or Y) blank to use the player's current X (or Y) position. (If blank, still include commas)
+				Put + or - before the number to replace relative to the player's current position. (ex. +10, -2, etc.).
+- room:			The ID (number/letter) of the room you're replacing in. (Refer to Game Data tab for Room IDs)
+				Leave blank to default to modifying the room the player is currently in.
+
+-- COPY DIALOG TAG REFERENCE -----------------------------------
+
+{copy "type, target, copyX, copyY, copyRoom, pasteX, pasteY, pasteRoom"}
+{copyNow "type, target, copyX, copyY, copyRoom, pasteX, pasteY, pasteRoom"}
+{copyBox "type, target, copyX1, copyY1, copyX2, copyY2, copyRoom, pasteX, pasteY, pasteRoom"}
+{copyBoxNow "type, target, copyX1, copyY1, copyX2, copyY2, copyRoom, pasteX, pasteY, pasteRoom"}
+{copyAll "type, target, copyRoom, pasteRoom"}
+{copyAllNow "type, target, copyRoom, pasteRoom"}
+
+Information:
+- "copy" find tiles, items, or sprites at a location in a room, and duplicates each at a new location (may be in a different room).
+- "copyBox" is as above, but copies tiles, items, or sprites in a box/line, defined by a top left and bottom right corner.
+- "copyAll" is as above, but affects an entire room.
+- Adding "Now" causes it to copy immediately, rather than waiting until the dialog ends.
+
+Parameters:
+- type:				Type of room contents to target for copying (ANY, TIL, ITM, or SPR).
+					Anything (ANY): Targetting anything will copy all valid Tiles, Items, and Sprites.
+					Tile (TIL): Each location can have only one Tile. Copying over an existing tile replaces it.
+					Item (ITM): Multiple items can exist in one spot, and all valid items will be copied.
+					Sprite (SPR): Only one copy of each Sprite can exist at a time; copying a sprite moves it.
+					Leaving this blank will default to targeting ANY. (If blank, still include commas)
+- target:			The ID (number/letter) of the tile, item, or sprite to copy. Other objects will not be copied.
+					Leave this blank, or set this to "ANY", to target all tiles, items, and/or sprites. (If blank, still include commas)
+- copyX, copyY:		The x and y coordinates you want to copy from, from 0-15.
+- copyX1, copyY1:	(For copyBox only) The x and y coordinates of the top left tile you want to copy from, from 0-15.
+- copyX2, copyY2:	(For copyBox only) The x and y coordinates of the bottom right tile you want to copy from, from 0-15.
+					Leave X (or Y) blank to use the player's current X (or Y) position. (If blank, still include commas)
+					Put + or - before the number to replace relative to the player's current position. (ex. +10, -2, etc.).
+- copyRoom:			The ID (number/letter) of the room you're copying from. (Refer to Game Data tab for Room IDs)
+					Leave blank to default to copy from the room the player is currently in.
+- pasteX, pasteY:	The x and y coordinates you want to paste copied tiles too, from 0-15.
+					For copyBox, this position marks the upper-left corner of the pasted box.
+- pasteRoom:		As above, but marks the ID (number/letter) of the room you're pasting into.
+					Leave blank to default to paste to the room the player is currently in.
+**/
+(function (bitsy) {
+'use strict';
+
+bitsy = bitsy && bitsy.hasOwnProperty('default') ? bitsy['default'] : bitsy;
+
+/**
+@file utils
+@summary miscellaneous bitsy utilities
+@author Sean S. LeBlanc
+*/
+
+/*
+Helper used to replace code in a script tag based on a search regex
+To inject code without erasing original string, using capturing groups; e.g.
+	inject(/(some string)/,'injected before $1 injected after')
+*/
+function inject(searchRegex, replaceString) {
+	// find the relevant script tag
+	var scriptTags = document.getElementsByTagName('script');
+	var scriptTag;
+	var code;
+	for (var i = 0; i < scriptTags.length; ++i) {
+		scriptTag = scriptTags[i];
+		var matchesSearch = scriptTag.textContent.search(searchRegex) !== -1;
+		var isCurrentScript = scriptTag === document.currentScript;
+		if (matchesSearch && !isCurrentScript) {
+			code = scriptTag.textContent;
+			break;
+		}
+	}
+
+	// error-handling
+	if (!code) {
+		throw 'Couldn\'t find "' + searchRegex + '" in script tags';
+	}
+
+	// modify the content
+	code = code.replace(searchRegex, replaceString);
+
+	// replace the old script tag with a new one using our modified code
+	var newScriptTag = document.createElement('script');
+	newScriptTag.textContent = code;
+	scriptTag.insertAdjacentElement('afterend', newScriptTag);
+	scriptTag.remove();
+}
+
+/**
+ * Helper for getting an array with unique elements 
+ * @param  {Array} array Original array
+ * @return {Array}       Copy of array, excluding duplicates
+ */
+function unique(array) {
+	return array.filter(function (item, idx) {
+		return array.indexOf(item) === idx;
+	});
+}
+
+/**
+
+@file kitsy-script-toolkit
+@summary makes it easier and cleaner to run code before and after Bitsy functions or to inject new code into Bitsy script tags
+@license WTFPL (do WTF you want)
+@version 4.0.1
+@requires Bitsy Version: 4.5, 4.6
+@author @mildmojo
+
+@description
+HOW TO USE:
+  import {before, after, inject, addDialogTag, addDeferredDialogTag} from "./helpers/kitsy-script-toolkit";
+
+  before(targetFuncName, beforeFn);
+  after(targetFuncName, afterFn);
+  inject(searchRegex, replaceString);
+  addDialogTag(tagName, dialogFn);
+  addDeferredDialogTag(tagName, dialogFn);
+
+  For more info, see the documentation at:
+  https://github.com/seleb/bitsy-hacks/wiki/Coding-with-kitsy
+*/
+
+
+// Ex: inject(/(names.sprite.set\( name, id \);)/, '$1console.dir(names)');
+function inject$1(searchRegex, replaceString) {
+	var kitsy = kitsyInit();
+	kitsy.queuedInjectScripts.push({
+		searchRegex: searchRegex,
+		replaceString: replaceString
+	});
+}
+
+// Ex: before('load_game', function run() { alert('Loading!'); });
+//     before('show_text', function run(text) { return text.toUpperCase(); });
+//     before('show_text', function run(text, done) { done(text.toUpperCase()); });
+function before(targetFuncName, beforeFn) {
+	var kitsy = kitsyInit();
+	kitsy.queuedBeforeScripts[targetFuncName] = kitsy.queuedBeforeScripts[targetFuncName] || [];
+	kitsy.queuedBeforeScripts[targetFuncName].push(beforeFn);
+}
+
+// Ex: after('load_game', function run() { alert('Loaded!'); });
+function after(targetFuncName, afterFn) {
+	var kitsy = kitsyInit();
+	kitsy.queuedAfterScripts[targetFuncName] = kitsy.queuedAfterScripts[targetFuncName] || [];
+	kitsy.queuedAfterScripts[targetFuncName].push(afterFn);
+}
+
+function kitsyInit() {
+	// return already-initialized kitsy
+	if (bitsy.kitsy) {
+		return bitsy.kitsy;
+	}
+
+	// Initialize kitsy
+	bitsy.kitsy = {
+		queuedInjectScripts: [],
+		queuedBeforeScripts: {},
+		queuedAfterScripts: {}
+	};
+
+	var oldStartFunc = bitsy.startExportedGame;
+	bitsy.startExportedGame = function doAllInjections() {
+		// Only do this once.
+		bitsy.startExportedGame = oldStartFunc;
+
+		// Rewrite scripts and hook everything up.
+		doInjects();
+		applyAllHooks();
+
+		// Start the game
+		bitsy.startExportedGame.apply(this, arguments);
+	};
+
+	return bitsy.kitsy;
+}
+
+
+function doInjects() {
+	bitsy.kitsy.queuedInjectScripts.forEach(function (injectScript) {
+		inject(injectScript.searchRegex, injectScript.replaceString);
+	});
+	_reinitEngine();
+}
+
+function applyAllHooks() {
+	var allHooks = unique(Object.keys(bitsy.kitsy.queuedBeforeScripts).concat(Object.keys(bitsy.kitsy.queuedAfterScripts)));
+	allHooks.forEach(applyHook);
+}
+
+function applyHook(functionName) {
+	var functionNameSegments = functionName.split('.');
+	var obj = bitsy;
+	while (functionNameSegments.length > 1) {
+		obj = obj[functionNameSegments.shift()];
+	}
+	var lastSegment = functionNameSegments[0];
+	var superFn = obj[lastSegment];
+	var superFnLength = superFn ? superFn.length : 0;
+	var functions = [];
+	// start with befores
+	functions = functions.concat(bitsy.kitsy.queuedBeforeScripts[functionName] || []);
+	// then original
+	if (superFn) {
+		functions.push(superFn);
+	}
+	// then afters
+	functions = functions.concat(bitsy.kitsy.queuedAfterScripts[functionName] || []);
+
+	// overwrite original with one which will call each in order
+	obj[lastSegment] = function () {
+		var returnVal;
+		var args = [].slice.call(arguments);
+		var i = 0;
+
+		function runBefore() {
+			// All outta functions? Finish
+			if (i === functions.length) {
+				return returnVal;
+			}
+
+			// Update args if provided.
+			if (arguments.length > 0) {
+				args = [].slice.call(arguments);
+			}
+
+			if (functions[i].length > superFnLength) {
+				// Assume funcs that accept more args than the original are
+				// async and accept a callback as an additional argument.
+				return functions[i++].apply(this, args.concat(runBefore.bind(this)));
+			} else {
+				// run synchronously
+				returnVal = functions[i++].apply(this, args);
+				if (returnVal && returnVal.length) {
+					args = returnVal;
+				}
+				return runBefore.apply(this, args);
+			}
+		}
+
+		return runBefore.apply(this, arguments);
+	};
+}
+
+function _reinitEngine() {
+	// recreate the script and dialog objects so that they'll be
+	// referencing the code with injections instead of the original
+	bitsy.scriptModule = new bitsy.Script();
+	bitsy.scriptInterpreter = bitsy.scriptModule.CreateInterpreter();
+
+	bitsy.dialogModule = new bitsy.Dialog();
+	bitsy.dialogRenderer = bitsy.dialogModule.CreateRenderer();
+	bitsy.dialogBuffer = bitsy.dialogModule.CreateBuffer();
+}
+
+// Rewrite custom functions' parentheses to curly braces for Bitsy's
+// interpreter. Unescape escaped parentheticals, too.
+function convertDialogTags(input, tag) {
+	return input
+		.replace(new RegExp('\\\\?\\((' + tag + '(\\s+(".+?"|.+?))?)\\\\?\\)', 'g'), function (match, group) {
+			if (match.substr(0, 1) === '\\') {
+				return '(' + group + ')'; // Rewrite \(tag "..."|...\) to (tag "..."|...)
+			}
+			return '{' + group + '}'; // Rewrite (tag "..."|...) to {tag "..."|...}
+		});
+}
+
+
+function addDialogFunction(tag, fn) {
+	var kitsy = kitsyInit();
+	kitsy.dialogFunctions = kitsy.dialogFunctions || {};
+	if (kitsy.dialogFunctions[tag]) {
+		throw new Error('The dialog function "' + tag + '" already exists.');
+	}
+
+	// Hook into game load and rewrite custom functions in game data to Bitsy format.
+	before('parseWorld', function (game_data) {
+		return [convertDialogTags(game_data, tag)];
+	});
+
+	kitsy.dialogFunctions[tag] = fn;
+}
+
+/**
+ * Adds a custom dialog tag which executes the provided function.
+ * For ease-of-use with the bitsy editor, tags can be written as
+ * (tagname "parameters") in addition to the standard {tagname "parameters"}
+ * 
+ * Function is executed immediately when the tag is reached.
+ *
+ * @param {string}   tag Name of tag
+ * @param {Function} fn  Function to execute, with signature `function(environment, parameters, onReturn){}`
+ *                       environment: provides access to SetVariable/GetVariable (among other things, see Environment in the bitsy source for more info)
+ *                       parameters: array containing parameters as string in first element (i.e. `parameters[0]`)
+ *                       onReturn: function to call with return value (just call `onReturn(null);` at the end of your function if your tag doesn't interact with the logic system)
+ */
+function addDialogTag(tag, fn) {
+	addDialogFunction(tag, fn);
+	inject$1(
+		/(var functionMap = new Map\(\);)/,
+		'$1functionMap.set("' + tag + '", kitsy.dialogFunctions.' + tag + ');'
+	);
+}
+
+/**
+ * Adds a custom dialog tag which executes the provided function.
+ * For ease-of-use with the bitsy editor, tags can be written as
+ * (tagname "parameters") in addition to the standard {tagname "parameters"}
+ * 
+ * Function is executed after the dialog box.
+ *
+ * @param {string}   tag Name of tag
+ * @param {Function} fn  Function to execute, with signature `function(environment, parameters){}`
+ *                       environment: provides access to SetVariable/GetVariable (among other things, see Environment in the bitsy source for more info)
+ *                       parameters: array containing parameters as string in first element (i.e. `parameters[0]`)
+ */
+function addDeferredDialogTag(tag, fn) {
+	addDialogFunction(tag, fn);
+	bitsy.kitsy.deferredDialogFunctions = bitsy.kitsy.deferredDialogFunctions || {};
+	var deferred = bitsy.kitsy.deferredDialogFunctions[tag] = [];
+	inject$1(
+		/(var functionMap = new Map\(\);)/,
+		'$1functionMap.set("' + tag + '", function(e, p, o){ kitsy.deferredDialogFunctions.' + tag + '.push({e:e,p:p}); o(null); });'
+	);
+	// Hook into the dialog finish event and execute the actual function
+	after('onExitDialog', function () {
+		while (deferred.length) {
+			var args = deferred.shift();
+			bitsy.kitsy.dialogFunctions[tag](args.e, args.p, args.o);
+		}
+	});
+	// Hook into the game reset and make sure data gets cleared
+	after('clearGameData', function () {
+		deferred.length = 0;
+	});
+}
+
+
+
+// Draws an Item, Sprite, or Tile at a location in a room
+// {draw "mapId, sourceId, xPos, yPos, roomID"}
+// {drawNow "mapId, sourceId, xPos, yPos, roomID"}
+addDialogTag('drawNow', function (environment, parameters, onReturn) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	drawAt(params[0], params[1], params[2], params[3], params[4]);
+	onReturn(null);
+});
+addDeferredDialogTag('draw', function (environment, parameters) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	drawAt(params[0], params[1], params[2], params[3], params[4]);
+});
+
+// As above, but affects a box area, between two corners.
+// {drawBox "mapId, sourceId, x1, y1, x2, y2, roomID"}
+// {drawBoxNow "mapId, sourceId, x1, y1, x2, y2, roomID"}
+addDialogTag('drawBoxNow', function (environment, parameters, onReturn) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	drawBoxAt(params[0], params[1], params[2], params[3], params[4], params[5], params[6]);
+	onReturn(null);
+});
+addDeferredDialogTag('drawBox', function (environment, parameters) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	drawBoxAt(params[0], params[1], params[2], params[3], params[4], params[5], params[6]);
+});
+
+// As above, but affects an entire room.
+// {drawAll "mapId, sourceId, roomID"}
+// {drawAllNow "mapId, sourceId, roomID"}
+addDialogTag('drawAllNow', function (environment, parameters, onReturn) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	drawBoxAt(params[0], params[1], 0, 0, 15, 15, params[2]);
+	onReturn(null);
+});
+addDeferredDialogTag('drawAll', function (environment, parameters) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	drawBoxAt(params[0], params[1], 0, 0, 15, 15, params[2]);
+});
+
+// Removes Items, Sprites, and/or Tiles at a location in a room
+// {erase "mapId, targetId, xPos, yPos, roomID"}
+// {eraseNow "mapId, targetId, xPos, yPos, roomID"}
+addDialogTag('eraseNow', function (environment, parameters, onReturn) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	eraseAt(params[0], params[1], params[2], params[3], params[4]);
+});
+addDeferredDialogTag('erase', function (environment, parameters) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	eraseAt(params[0], params[1], params[2], params[3], params[4]);
+});
+
+// As above, but affects a box area, between two corners.
+// {eraseBox "mapId, targetId, x1, y1, x2, y2, roomID"}
+// {eraseBoxNow "mapId, targetId, x1, y1, x2, y2, roomID"}
+addDialogTag('eraseBoxNow', function (environment, parameters, onReturn) { 
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	eraseBoxAt(params[0], params[1], params[2], params[3], params[4], params[5], params[6]);
+	onReturn(null);
+});
+addDeferredDialogTag('eraseBox', function (environment, parameters) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	eraseBoxAt(params[0], params[1], params[2], params[3], params[4], params[5], params[6]);
+});
+
+// As above, but affects an entire room.
+// {eraseAll "mapId, targetId, roomID"}
+// {eraseAllNow "mapId, targetId, roomID"}
+addDialogTag('eraseAllNow', function (environment, parameters, onReturn) { 
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	eraseBoxAt(params[0], params[1], 0, 0, 15, 15, params[2]);
+	onReturn(null);
+});
+addDeferredDialogTag('eraseAll', function (environment, parameters) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	eraseBoxAt(params[0], params[1], 0, 0, 15, 15, params[2]);
+});
+
+// Converts instances of target Item, Sprite, or Tile at a location in a room into something new
+// {replace "targetMapId, targetId, newMapId, newId, xPos, yPos, roomID"}
+// {replaceNow "targetMapId, targetId, newMapId, newId, xPos, yPos, roomID"}
+addDialogTag('replaceNow', function (environment, parameters, onReturn) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	replaceAt(params[0], params[1], params[2], params[3], params[4], params[5], params[6]);
+});
+addDeferredDialogTag('replace', function (environment, parameters) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	replaceAt(params[0], params[1], params[2], params[3], params[4], params[5], params[6]);
+});
+
+// As above, but affects a box area between two corners.
+// {replaceBox "targetMapId, targetId, newMapId, newId, x1, y1, x2, y2, roomID"}
+// {replaceBoxNow "targetMapId, targetId, newMapId, newId, x1, y1, x2, y2, roomID"}
+addDialogTag('replaceBoxNow', function (environment, parameters, onReturn) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	replaceBoxAt(params[0], params[1], params[2], params[3], params[4], params[5], params[6], params[7], params[8]);
+});
+addDeferredDialogTag('replaceBox', function (environment, parameters) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	replaceBoxAt(params[0], params[1], params[2], params[3], params[4], params[5], params[6], params[7], params[8]);
+});
+
+// As above, but affects an entire room.
+// {replaceAll "targetMapId, targetId, newMapId, roomID"}
+// {replaceAllNow "targetMapId, targetId, newMapId, newId, roomID"}
+addDialogTag('replaceAllNow', function (environment, parameters, onReturn) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	replaceBoxAt(params[0], params[1], params[2], params[3], 0, 0, 15, 15, params[4]);
+});
+addDeferredDialogTag('replaceAll', function (environment, parameters) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	replaceBoxAt(params[0], params[1], params[2], params[3], 0, 0, 15, 15, params[4]);
+});
+
+// Duplicates Items, Sprites, and/or Tiles from one location in a room to another
+// {copy "mapId, targetId, copyX, copyY, copyRoom, pasteX, pasteY, pasteRoom"}
+// {copyNow "mapId, targetId, copyX, copyY, copyRoom, pasteX, pasteY, pasteRoom"}
+addDialogTag('copyNow', function (environment, parameters, onReturn) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	copyAt(params[0], params[1], params[2], params[3], params[4], params[5], params[6], params[7]);
+	onReturn(null);
+});
+addDeferredDialogTag('copy', function (environment, parameters) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	copyAt(params[0], params[1], params[2], params[3], params[4], params[5], params[6], params[7]);
+});
+
+// As above, but copies a box area between two corners, and pastes at a new spot designating the upper-left corner
+// NOTE: positioning the paste coordinates out of bounds will only draw the section overlapping with the room.
+// {copyBox "mapId, targetId, copyX1, copyY1, copyX2, copyY2, copyRoom, pasteX, pasteY, pasteRoom"}
+// {copyBoxNow "mapId, targetId, copyX1, copyY1, copyX2, copyY2, copyRoom, pasteX, pasteY, pasteRoom"}
+addDialogTag('copyBoxNow', function (environment, parameters, onReturn) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	copyBoxAt(params[0], params[1], params[2], params[3], params[4], params[5], params[6], params[7], params[8], params[9]);
+	onReturn(null);
+});
+addDeferredDialogTag('copyBox', function (environment, parameters) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	copyBoxAt(params[0], params[1], params[2], params[3], params[4], params[5], params[6], params[7], params[8], params[9]);
+});
+
+// As above, but affects an entire room.
+// {copyAll "mapId, targetId, copyRoom, pasteRoom"}
+// {copyAllNow "mapId, targetId, copyRoom, pasteRoom"}
+addDialogTag('copyAllNow', function (environment, parameters, onReturn) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	copyBoxAt(params[0], params[1], 0, 0, 15, 15, params[3], 0, 0, params[4]);
+	onReturn(null);
+});
+addDeferredDialogTag('copyAll', function (environment, parameters) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	copyBoxAt(params[0], params[1], 0, 0, 15, 15, params[3], 0, 0, params[4]);
+});
+
+function drawAt (mapId, sourceId, xPos, yPos, roomId) {
+	// Trim and sanitize Map ID / Type parameter, and return if not provided.
+	if (mapId == undefined) {
+		console.log("CAN'T DRAW. DRAW TYPE IS UNDEFINED. TIL, ITM, OR SPR EXPECTED.");
+		return;
+	}
+	else {
+		mapId = mapId.toString().trim();
+		if (mapId == "" || !(mapId.toUpperCase() == "TIL" || mapId.toUpperCase() == "ITM" || mapId.toUpperCase() == "SPR")) {
+			console.log("CAN'T DRAW. UNEXPECTED DRAW TYPE ("+mapId+"). TIL, ITM, OR SPR EXPECTED.");
+			return;
+		}
+	}
+
+	// Trim and sanitize Source ID parameter, and return if not provided
+	if (sourceId == undefined) {
+		console.log("CAN'T DRAW. SOURCE ID IS UNDEFINED. TILE, ITEM, OR SPRITE ID EXPECTED.");
+		return;
+	}
+	else {
+		sourceId = sourceId.toString().trim();
+		if (sourceId == "") {
+			console.log("CAN'T DRAW. NO SOURCE ID GIVEN. TILE, ITEM, OR SPRITE ID EXPECTED.");
+			return;
+		}
+	}
+
+	// Trim and sanitize X Position parameter, and set relative positions, even if omitted.
+	if (xPos == undefined) {
+		xPos = player().x;
+	}
+	else {
+		xPos = xPos.toString().trim();
+		if (xPos == "" ) { xPos = player().x; }
+		else if (xPos.includes("+")) { xPos = player().x + parseInt(xPos.substring(1)); }
+		else if (xPos.includes("-")) { xPos = player().x - parseInt(xPos.substring(1)); }
+	}
+	if (xPos < 0 || xPos > 15) {
+		console.log("CAN'T DRAW. X POSITION ("+xPos+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		return;
+	}
+
+	// Trim and sanitize Y Position parameter, and set relative positions, even if omitted
+	if (yPos == undefined) {
+		yPos = player().y;
+	}
+	else {
+		yPos = yPos.toString().trim();
+		if (yPos == "" ) { yPos = player().y; }
+		else if (yPos.includes("+")) { yPos = player().y + parseInt(yPos.substring(1)); }
+		else if (yPos.includes("-")) { yPos = player().y - parseInt(yPos.substring(1)); }
+	}
+	if (yPos < 0 || yPos > 15) {
+		console.log("CAN'T DRAW. Y POSITION ("+yPos+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		return;
+	}
+	
+	// Trim and sanitize Room ID parameter, and set to current room if omitted
+	if (roomId == undefined) {
+		roomId = curRoom;
+	}
+	else {
+		roomId = roomId.toString().trim();
+		if (roomId == "" ) { roomId = curRoom; }
+		else if (room[roomId] == undefined) {
+			console.log("CAN'T DRAW. ROOM ID ("+roomId+") NOT FOUND.");
+			return;
+		}
+	}
+
+	//console.log ("DRAWING "+mapId+" "+sourceId+" at "+xPos+","+yPos+"(Room "+roomId+")");
+
+	if (mapId.toUpperCase() == "TIL") {
+		if (tile[sourceId] != undefined) {
+			room[roomId].tilemap[yPos][xPos] = sourceId;
+		}
+	}
+	else if (mapId.toUpperCase() == "ITM") {
+		if (item[sourceId] != undefined) {
+			var newItem = {
+				id: sourceId,
+				x: xPos,
+				y: yPos
+			};
+			room[roomId].items.push(newItem);
+		}
+	}
+	else if (mapId.toUpperCase() == "SPR") {
+		if (sprite[sourceId] != undefined) {
+			if (sprite[sourceId].id == "A") {
+				console.log("CAN'T TARGET AVATAR. SKIPPING.");
+			}
+			else if (room[roomId] != undefined) {
+				sprite[sourceId].room = roomId;
+				sprite[sourceId].x = xPos;
+				sprite[sourceId].y = yPos;
+			}
+		}
+	}
+}
+
+function drawBoxAt (mapId, sourceId, x1, y1, x2, y2, roomId) {
+	
+	// Trim and sanitize X and Y Positions, and set relative positions if omitted.
+	if (x1 == undefined) {
+		x1 = player().x;
+	}
+	else {
+		x1 = x1.toString().trim();
+		if (x1 == "" ) { x1 = player().x; }
+		else if (x1.includes("+")) { x1 = player().x + parseInt(x1.substring(1)); }
+		else if (x1.includes("-")) { x1 = player().x - parseInt(x1.substring(1)); }
+	}
+	if (x1 < 0 || x1 > 15) {
+		console.log("CLAMPING X1 POSITION. XPOS ("+x1+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		x1 = Math.max(0, Math.min(x1, 15));
+	}
+	// X2
+	if (x2 == undefined) {
+		x2 = player().x;
+	}
+	else {
+		x2 = x2.toString().trim();
+		if (x2 == "" ) { x2 = player().x; }
+		else if (x2.includes("+")) { x2 = player().x + parseInt(x2.substring(1)); }
+		else if (x2.includes("-")) { x2 = player().x - parseInt(x2.substring(1)); }
+	}
+	if (x2 < 0 || x2 > 15) {
+		console.log("CLAMPING X2 POSITION. xPos ("+x2+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		x2 = Math.max(0, Math.min(x2, 15));
+	}
+	// Y1
+	if (y1 == undefined) {
+		y1 = player().y;
+	}
+	else {
+		y1 = y1.toString().trim();
+		if (y1 == "" ) { y1 = player().y; }
+		else if (y1.includes("+")) { y1 = player().y + parseInt(y1.substring(1)); }
+		else if (y1.includes("-")) { y1 = player().y - parseInt(y1.substring(1)); }
+	}
+	if (y1 < 0 || y1 > 15) {
+		console.log("CLAMPING Y1 POSITION. XPOS ("+y1+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		y1 = Math.max(0, Math.min(y1, 15));
+	}
+	// Y2
+	if (y2 == undefined) {
+		y2 = player().y;
+	}
+	else {
+		y2 = y2.toString().trim();
+		if (y2 == "" ) { y2 = player().y; }
+		else if (y2.includes("+")) { y2 = player().y + parseInt(y2.substring(1)); }
+		else if (y2.includes("-")) { y2 = player().y - parseInt(y2.substring(1)); }
+	}
+	if (y2 < 0 || y2 > 15) {
+		console.log("CLAMPING Y2 POSITION. xPos ("+y2+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		y2 = Math.max(0, Math.min(y2, 15));
+	}
+
+	// Calculate which coordinates are the actual top left and bottom right.
+	var topPos = Math.min(y1, y2);
+	var leftPos = Math.min(x1, x2);
+	var bottomPos = Math.max(y1, y2);
+	var rightPos = Math.max(x1, x2);
+
+	for (var xPos = leftPos; xPos <= rightPos; xPos++) {
+		for (var yPos = topPos; yPos <= bottomPos; yPos++) {
+			drawAt(mapId, sourceId, xPos, yPos, roomId);
+		}
+	}
+}
+
+function eraseAt (mapId, targetId, xPos, yPos, roomId) {
+	// Trim and sanitize Map ID / Type parameter, and use any if not provided.
+	if (mapId == undefined) {
+		//console.log("ERASE TYPE IS UNDEFINED. DEFAULTING TO ANY (TIL, ITM, OR SPR).");
+		mapId = "ANY";
+	}
+	else {
+		mapId = mapId.toString().trim();
+		if (mapId == "" || !(mapId.toUpperCase() == "ANY" || mapId.toUpperCase() == "TIL" || mapId.toUpperCase() == "ITM" || mapId.toUpperCase() == "SPR")) {
+			//console.log("UNEXPECTED ERASE TYPE ("+mapId+"). DEFAULTING TO ANY (TIL, ITM, OR SPR).");
+			mapId = "ANY";
+		}
+	}
+
+	// Trim and sanitize Target ID parameter, and use any if not provided
+	if (targetId == undefined) {
+		//console.log("TARGET ID UNDEFINED. DEFAULTING TO ANY (ANYTHING OF VALID TYPE).");
+		targetId = "ANY";
+	}
+	else {
+		targetId = targetId.toString().trim();
+		if (targetId == "") {
+			//console.log("NO TARGET ID GIVEN. DEFAULTING TO ANY (ANYTHING OF VALID TYPE).");
+			targetId = "ANY";
+		}
+		//mapId = (mapId != "" || mapId.toUpperCase() != "ANY") ? mapId : "ANY";
+	}
+
+	// Trim and sanitize X Position parameter, and set relative positions, even if omitted.
+	if (xPos == undefined) {
+		xPos = player().x;
+	}
+	else {
+		xPos = xPos.toString().trim();
+		if (xPos == "" ) { xPos = player().x; }
+		else if (xPos.includes("+")) { xPos = player().x + parseInt(xPos.substring(1)); }
+		else if (xPos.includes("-")) { xPos = player().x - parseInt(xPos.substring(1)); }
+	}
+	if (xPos < 0 || xPos > 15) {
+		console.log("CAN'T DRAW. X POSITION ("+xPos+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		return;
+	}
+
+	// Trim and sanitize Y Position parameter, and set relative positions, even if omitted
+	if (yPos == undefined) {
+		yPos = player().y;
+	}
+	else {
+		yPos = yPos.toString().trim();
+		if (yPos == "" ) { yPos = player().y; }
+		else if (yPos.includes("+")) { yPos = player().y + parseInt(yPos.substring(1)); }
+		else if (yPos.includes("-")) { yPos = player().y - parseInt(yPos.substring(1)); }
+	}
+	if (yPos < 0 || yPos > 15) {
+		console.log("CAN'T DRAW. Y POSITION ("+yPos+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		return;
+	}
+	
+	// Trim and sanitize Room ID parameter, and set to current room if omitted
+	if (roomId == undefined) {
+		roomId = curRoom;
+	}
+	else {
+		roomId = roomId.toString().trim();
+		if (roomId == "" ) { roomId = curRoom; }
+		else if (room[roomId] == undefined) {
+			console.log("CAN'T DRAW. ROOM ID ("+roomId+") NOT FOUND.");
+			return;
+		}
+	}
+
+	//console.log ("REMOVING "+mapId+" "+targetId+" at "+xPos+","+yPos+"(Room "+roomId+")");
+	
+	// If TIL or undefined.
+	if (mapId.toUpperCase() != "ITM" && mapId.toUpperCase() != "SPR") {
+		if (targetId == "ANY" || room[roomId].tilemap[yPos][xPos] == targetId) {
+			room[roomId].tilemap[yPos][xPos] = "0";
+		}
+	}
+	
+	// If ITM or undefined.
+	if (mapId.toUpperCase() != "TIL" && mapId.toUpperCase() != "SPR") {
+		// Iterate backwards through items, to prevent issues with removed indexes
+		for (var i = room[roomId].items.length-1; i >= 0; i--) {
+			var targetItem = room[roomId].items[i];
+			if (targetId == "ANY" || targetId == targetItem.id) {
+				if (targetItem.x == xPos && targetItem.y == yPos) {
+					room[roomId].items.splice(i, 1);
+				}
+			}
+		}
+	}
+	
+	// If SPR or undefined.
+	if (mapId.toUpperCase() != "TIL" && mapId.toUpperCase() != "ITM") {
+		if (targetId == "ANY") {
+			for (i in sprite) {
+				if (sprite[i].id == "A") {
+					console.log("CAN'T TARGET AVATAR. SKIPPING.");
+				}
+				else if (sprite[i].room == roomId && sprite[i].x == xPos && sprite[i].y == yPos) {
+					sprite[i].x = 0;
+					sprite[i].y = 0;
+					sprite[i].room = "default";
+				}
+			}
+		}
+		else if (sprite[targetId] != undefined) {
+			if (sprite[targetId].id == "A") {
+				console.log("CAN'T TARGET AVATAR. SKIPPING.");
+			}
+			else if (sprite[targetId].room == roomId && sprite[targetId].x == xPos && sprite[targetId].y == yPos) {
+				sprite[targetId].x = 0;
+				sprite[targetId].y = 0;
+				sprite[targetId].room = "default";
+			}
+		}
+	}
+}
+
+function eraseBoxAt (mapId, targetId, x1, y1, x2, y2, roomId) {
+	// Trim and sanitize X and Y Positions, and set relative positions if omitted.
+	if (x1 == undefined) {
+		x1 = player().x;
+	}
+	else {
+		x1 = x1.toString().trim();
+		if (x1 == "" ) { x1 = player().x; }
+		else if (x1.includes("+")) { x1 = player().x + parseInt(x1.substring(1)); }
+		else if (x1.includes("-")) { x1 = player().x - parseInt(x1.substring(1)); }
+	}
+	if (x1 < 0 || x1 > 15) {
+		console.log("CLAMPING X1 POSITION. XPOS ("+x1+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		x1 = Math.max(0, Math.min(x1, 15));
+	}
+	// X2
+	if (x2 == undefined) {
+		x2 = player().x;
+	}
+	else {
+		x2 = x2.toString().trim();
+		if (x2 == "" ) { x2 = player().x; }
+		else if (x2.includes("+")) { x2 = player().x + parseInt(x2.substring(1)); }
+		else if (x2.includes("-")) { x2 = player().x - parseInt(x2.substring(1)); }
+	}
+	if (x2 < 0 || x2 > 15) {
+		console.log("CLAMPING X2 POSITION. xPos ("+x2+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		x2 = Math.max(0, Math.min(x2, 15));
+	}
+	// Y1
+	if (y1 == undefined) {
+		y1 = player().y;
+	}
+	else {
+		y1 = y1.trim();
+		if (y1 == "" ) { y1 = player().y; }
+		else if (y1.includes("+")) { y1 = player().y + parseInt(y1.substring(1)); }
+		else if (y1.includes("-")) { y1 = player().y - parseInt(y1.substring(1)); }
+	}
+	if (y1 < 0 || y1 > 15) {
+		console.log("CLAMPING Y1 POSITION. XPOS ("+y1+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		y1 = Math.max(0, Math.min(y1, 15));
+	}
+	// Y2
+	if (y2 == undefined) {
+		y2 = player().y;
+	}
+	else {
+		y2 = y2.toString().trim();
+		if (y2 == "" ) { y2 = player().y; }
+		else if (y2.includes("+")) { y2 = player().y + parseInt(y2.substring(1)); }
+		else if (y2.includes("-")) { y2 = player().y - parseInt(y2.substring(1)); }
+	}
+	if (y2 < 0 || y2 > 15) {
+		console.log("CLAMPING Y2 POSITION. xPos ("+y2+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		y2 = Math.max(0, Math.min(y2, 15));
+	}
+
+	// Calculate which coordinates are the actual top left and bottom right.
+	var topPos = Math.min(y1, y2);
+	var leftPos = Math.min(x1, x2);
+	var bottomPos = Math.max(y1, y2);
+	var rightPos = Math.max(x1, x2);
+
+	for (var xPos = leftPos; xPos <= rightPos; xPos++) {
+		for (var yPos = topPos; yPos <= bottomPos; yPos++) {
+			eraseAt(mapId, targetId, xPos, yPos, roomId);
+		}
+	}
+}
+
+function replaceAt (targetMapId, targetId, newMapId, newId, xPos, yPos, roomId) {
+	// Trim and sanitize Target Map ID / Type parameter, and use any if not provided.
+	if (targetMapId == undefined) {
+		//console.log("TARGET TYPE IS UNDEFINED. DEFAULTING TO ANY (TIL, ITM, OR SPR).");
+		targetMapId = "ANY";
+	}
+	else {
+		targetMapId = targetMapId.toString().trim();
+		if (targetMapId == "" || !(targetMapId.toUpperCase() == "ANY" || targetMapId.toUpperCase() == "TIL" || targetMapId.toUpperCase() == "ITM" || targetMapId.toUpperCase() == "SPR")) {
+			//console.log("UNEXPECTED TARGET TYPE ("+targetMapId+"). DEFAULTING TO ANY (TIL, ITM, OR SPR).");
+			targetMapId = "ANY";
+		}
+	}
+
+	// Trim and sanitize Target ID parameter, and use any if not provided
+	if (targetId == undefined) {
+		//console.log("TARGET ID UNDEFINED. DEFAULTING TO ANY (ANYTHING OF VALID TYPE).");
+		targetId = "ANY";
+	}
+	else {
+		targetId = targetId.toString().trim();
+		if (targetId == "") {
+			//console.log("NO TARGET ID GIVEN. DEFAULTING TO ANY (ANYTHING OF VALID TYPE).");
+			targetId = "ANY";
+		}
+	}
+
+	// Trim and sanitize New Map ID / Type parameter, and return if not provided.
+	if (newMapId == undefined) {
+		console.log("CANNOT REPLACE. REPLACING TYPE IS UNDEFINED. TIL, ITM, OR SPR EXPECTED.");
+		return;
+	}
+	else {
+		newMapId = newMapId.toString().trim();
+		if (newMapId == "" || !(newMapId.toUpperCase() == "TIL" || newMapId.toUpperCase() == "ITM" || newMapId.toUpperCase() == "SPR")) {
+			console.log("CANNOT REPLACE. UNEXPECTED REPLACING TYPE ("+newMapId+"). TIL, ITM, OR SPR EXPECTED.");
+			return;
+		}
+	}
+
+	// Trim and sanitize New Target ID parameter, and return if not provided
+	if (newId == undefined) {
+		console.log("CANNOT REPLACE. NEW TARGET ID UNDEFINED. VALID ID EXPECTED).");
+		return;
+	}
+	else {
+		newId = newId.toString().trim();
+		if (newId == "") {
+			console.log("CANNOT REPLACE. NO NEW TARGET ID GIVEN. VALID ID EXPECTED");
+			return;
+		}
+	}
+
+	// Trim and sanitize X Position parameter, and set relative positions, even if omitted.
+	if (xPos == undefined) {
+		xPos = player().x;
+	}
+	else {
+		xPos = xPos.toString().trim();
+		if (xPos == "" ) { xPos = player().x; }
+		else if (xPos.includes("+")) { xPos = player().x + parseInt(xPos.substring(1)); }
+		else if (xPos.includes("-")) { xPos = player().x - parseInt(xPos.substring(1)); }
+	}
+	if (xPos < 0 || xPos > 15) {
+		console.log("CAN'T REPLACE. X POSITION ("+xPos+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		return;
+	}
+
+	// Trim and sanitize Y Position parameter, and set relative positions, even if omitted
+	if (yPos == undefined) {
+		yPos = player().y;
+	}
+	else {
+		yPos = yPos.toString().trim();
+		if (yPos == "" ) { yPos = player().y; }
+		else if (yPos.includes("+")) { yPos = player().y + parseInt(yPos.substring(1)); }
+		else if (yPos.includes("-")) { yPos = player().y - parseInt(yPos.substring(1)); }
+	}
+	if (yPos < 0 || yPos > 15) {
+		console.log("CAN'T REPLACE. Y POSITION ("+yPos+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		return;
+	}
+	
+	// Trim and sanitize Room ID parameter, and set to current room if omitted
+	if (roomId == undefined) {
+		roomId = curRoom;
+	}
+	else {
+		roomId = roomId.toString().trim();
+		if (roomId == "" ) { roomId = curRoom; }
+		else if (room[roomId] == undefined) {
+			console.log("CAN'T REPLACE. ROOM ID ("+roomId+") NOT FOUND.");
+			return;
+		}
+	}
+
+	//console.log ("REPLACING "+targetMapId+" "+targetId+" at "+xPos+","+yPos+"(Room "+roomId+")");
+	//console.log ("REPLACING WITH "+newMapId+" "+newId);
+	
+	// If TIL or undefined.
+	if (targetMapId.toUpperCase() != "ITM" && targetMapId.toUpperCase() != "SPR") {
+		if (targetId == "ANY" || room[roomId].tilemap[yPos][xPos] == targetId) {
+			room[roomId].tilemap[yPos][xPos] = "0";
+			drawAt(newMapId, newId, xPos, yPos, roomId);
+		}
+	}
+	
+	// If ITM or undefined.
+	if (targetMapId.toUpperCase() != "TIL" && targetMapId.toUpperCase() != "SPR") {
+		// Iterate backwards through items, to prevent issues with removed indexes
+		for (var i = room[roomId].items.length-1; i >= 0; i--) {
+			var targetItem = room[roomId].items[i];
+			if (targetId == "ANY" || targetId == targetItem.id) {
+				if (targetItem.x == xPos && targetItem.y == yPos) {
+					room[roomId].items.splice(i, 1);
+					drawAt(newMapId, newId, xPos, yPos, roomId);
+				}
+			}
+		}
+	}
+	
+	// If SPR or undefined.
+	if (targetMapId.toUpperCase() != "TIL" && targetMapId.toUpperCase() != "ITM") {
+		if (targetId == "ANY") {
+			for (i in sprite) {
+				if (sprite[i].id == "A") {
+					console.log("CAN'T TARGET AVATAR. SKIPPING.");
+				}
+				else if (sprite[i].room == roomId && sprite[i].x == xPos && sprite[i].y == yPos) {
+					sprite[i].x = 0;
+					sprite[i].y = 0;
+					sprite[i].room = "default";
+					drawAt(newMapId, newId, xPos, yPos, roomId);
+				}
+			}
+		}
+		else if (sprite[targetId] != undefined) {
+			if (sprite[targetId] != "A" && sprite[targetId].room == roomId && sprite[targetId].x == xPos && sprite[targetId].y == yPos) {
+				sprite[targetId].x = 0;
+				sprite[targetId].y = 0;
+				sprite[targetId].room = "default";
+				drawAt(newMapId, newId, xPos, yPos, roomId);
+			}
+		}
+	}
+}
+
+function replaceBoxAt (targetMapId, targetId, newMapId, newId, x1, y1, x2, y2, roomId) {
+	// Trim and sanitize X and Y Positions, and set relative positions if omitted.
+	if (x1 == undefined) {
+		x1 = player().x;
+	}
+	else {
+		x1 = x1.toString().trim();
+		if (x1 == "" ) { x1 = player().x; }
+		else if (x1.includes("+")) { x1 = player().x + parseInt(x1.substring(1)); }
+		else if (x1.includes("-")) { x1 = player().x - parseInt(x1.substring(1)); }
+	}
+	if (x1 < 0 || x1 > 15) {
+		console.log("CLAMPING X1 POSITION. XPOS ("+x1+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		x1 = Math.max(0, Math.min(x1, 15));
+	}
+	// X2
+	if (x2 == undefined) {
+		x2 = player().x;
+	}
+	else {
+		x2 = x2.toString().trim();
+		if (x2 == "" ) { x2 = player().x; }
+		else if (x2.includes("+")) { x2 = player().x + parseInt(x2.substring(1)); }
+		else if (x2.includes("-")) { x2 = player().x - parseInt(x2.substring(1)); }
+	}
+	if (x2 < 0 || x2 > 15) {
+		console.log("CLAMPING X2 POSITION. xPos ("+x2+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		x2 = Math.max(0, Math.min(x2, 15));
+	}
+	// Y1
+	if (y1 == undefined) {
+		y1 = player().y;
+	}
+	else {
+		y1 = y1.toString().trim();
+		if (y1 == "" ) { y1 = player().y; }
+		else if (y1.includes("+")) { y1 = player().y + parseInt(y1.substring(1)); }
+		else if (y1.includes("-")) { y1 = player().y - parseInt(y1.substring(1)); }
+	}
+	if (y1 < 0 || y1 > 15) {
+		console.log("CLAMPING Y1 POSITION. XPOS ("+y1+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		y1 = Math.max(0, Math.min(y1, 15));
+	}
+	// Y2
+	if (y2 == undefined) {
+		y2 = player().y;
+	}
+	else {
+		y2 = y2.toString().trim();
+		if (y2 == "" ) { y2 = player().y; }
+		else if (y2.includes("+")) { y2 = player().y + parseInt(y2.substring(1)); }
+		else if (y2.includes("-")) { y2 = player().y - parseInt(y2.substring(1)); }
+	}
+	if (y2 < 0 || y2 > 15) {
+		console.log("CLAMPING Y2 POSITION. xPos ("+y2+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		y2 = Math.max(0, Math.min(y2, 15));
+	}
+
+	// Calculate which coordinates are the actual top left and bottom right.
+	var topPos = Math.min(y1, y2);
+	var leftPos = Math.min(x1, x2);
+	var bottomPos = Math.max(y1, y2);
+	var rightPos = Math.max(x1, x2);
+
+	for (var xPos = leftPos; xPos <= rightPos; xPos++) {
+		for (var yPos = topPos; yPos <= bottomPos; yPos++) {
+			replaceAt(targetMapId, targetId, newMapId, newId, xPos, yPos, roomId);
+		}
+	}
+}
+
+function copyAt (mapId, targetId, copyXPos, copyYPos, copyRoomId, pasteXPos, pasteYPos, pasteRoomId) {
+	// Trim and sanitize Target Map ID / Type parameter, and use any if not provided.
+	if (mapId == undefined) {
+		//console.log("TARGET TYPE IS UNDEFINED. DEFAULTING TO ANY (TIL, ITM, OR SPR).");
+		mapId = "ANY";
+	}
+	else {
+		mapId = mapId.toString().trim();
+		if (mapId == "" || !(mapId.toUpperCase() == "ANY" || mapId.toUpperCase() == "TIL" || mapId.toUpperCase() == "ITM" || mapId.toUpperCase() == "SPR")) {
+			//console.log("UNEXPECTED TARGET TYPE ("+mapId+"). DEFAULTING TO ANY (TIL, ITM, OR SPR).");
+			mapId = "ANY";
+		}
+	}
+
+	// Trim and sanitize Target ID parameter, and use any if not provided
+	if (targetId == undefined) {
+		//console.log("TARGET ID UNDEFINED. DEFAULTING TO ANY (ANYTHING OF VALID TYPE).");
+		targetId = "ANY";
+	}
+	else {
+		targetId = targetId.toString().trim();
+		if (targetId == "") {
+			//console.log("NO TARGET ID GIVEN. DEFAULTING TO ANY (ANYTHING OF VALID TYPE).");
+			targetId = "ANY";
+		}
+	}
+
+	// Trim and sanitize Copy Position parameters, and set relative positions, even if omitted.
+	if (copyXPos == undefined) {
+		copyXPos = player().x;
+	}
+	else {
+		copyXPos = copyXPos.toString().trim();
+		if (copyXPos == "" ) { copyXPos = player().x; }
+		else if (copyXPos.includes("+")) { copyXPos = player().x + parseInt(copyXPos.substring(1)); }
+		else if (copyXPos.includes("-")) { copyXPos = player().x - parseInt(copyXPos.substring(1)); }
+	}
+	if (copyXPos < 0 || copyXPos > 15) {
+		console.log("CAN'T COPY. X POSITION ("+copyXPos+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		return;
+	}
+
+	if (copyYPos == undefined) {
+		copyYPos = player().y;
+	}
+	else {
+		copyYPos = copyYPos.toString().trim();
+		if (copyYPos == "" ) { copyYPos = player().y; }
+		else if (copyYPos.includes("+")) { copyYPos = player().y + parseInt(copyYPos.substring(1)); }
+		else if (copyYPos.includes("-")) { copyYPos = player().y - parseInt(copyYPos.substring(1)); }
+	}
+	if (copyYPos < 0 || copyYPos > 15) {
+		console.log("CAN'T COPY. Y POSITION ("+copyYPos+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		return;
+	}
+	
+	if (copyRoomId == undefined) {
+		copyRoomId = curRoom;
+	}
+	else {
+		copyRoomId = copyRoomId.trim();
+		if (copyRoomId == "" ) { copyRoomId = curRoom; }
+		else if (room[copyRoomId] == undefined) {
+			console.log("CAN'T COPY. ROOM ID ("+copyRoomId+") NOT FOUND.");
+			return;
+		}
+	}
+
+	// Trim and sanitize Paste Position parameters, and set relative positions, even if omitted.
+	if (pasteXPos == undefined) {
+		pasteXPos = player().x;
+	}
+	else {
+		pasteXPos = pasteXPos.toString().trim();
+		if (pasteXPos == "" ) { pasteXPos = player().x; }
+		else if (pasteXPos.includes("+")) { pasteXPos = player().x + parseInt(pasteXPos.substring(1)); }
+		else if (pasteXPos.includes("-")) { pasteXPos = player().x - parseInt(pasteXPos.substring(1)); }
+	}
+	if (pasteXPos < 0 || pasteXPos > 15) {
+		console.log("CAN'T PASTE. X POSITION ("+pasteXPos+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		return;
+	}
+
+	if (pasteYPos == undefined) {
+		pasteYPos = player().y;
+	}
+	else {
+		pasteYPos = pasteYPos.toString().trim();
+		if (pasteYPos == "" ) { pasteYPos = player().y; }
+		else if (pasteYPos.includes("+")) { pasteYPos = player().y + parseInt(pasteYPos.substring(1)); }
+		else if (pasteYPos.includes("-")) { pasteYPos = player().y - parseInt(pasteYPos.substring(1)); }
+	}
+	if (pasteYPos < 0 || pasteYPos > 15) {
+		console.log("CAN'T PASTE. Y POSITION ("+pasteYPos+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		return;
+	}
+	
+	if (pasteRoomId == undefined) {
+		pasteRoomId = curRoom;
+	}
+	else {
+		pasteRoomId = pasteRoomId.toString().trim();
+		if (pasteRoomId == "" ) { pasteRoomId = curRoom; }
+		else if (room[pasteRoomId] == undefined) {
+			console.log("CAN'T PASTE. ROOM ID ("+pasteRoomId+") NOT FOUND.");
+			return;
+		}
+	}
+
+	//console.log ("COPYING "+mapId+" "+targetId+" at "+copyXPos+","+copyYPos+"(Room "+copyRoomId+")");
+	//console.log ("PASTING AT "+pasteXPos+","+pasteYPos+"(Room "+pasteRoomId+")");
+	
+	// If TIL or undefined.
+	if (mapId.toUpperCase() != "ITM" && mapId.toUpperCase() != "SPR") {
+		if (targetId == "ANY" || room[copyRoomId].tilemap[copyYPos][copyXPos] == targetId) {
+			var copyId = room[copyRoomId].tilemap[copyYPos][copyXPos];
+			drawAt("TIL", copyId, pasteXPos, pasteYPos, pasteRoomId);
+		}
+	}
+	
+	// If ITM or undefined.
+	if (mapId.toUpperCase() != "TIL" && mapId.toUpperCase() != "SPR") {
+		// Iterate backwards through items, to prevent issues with removed indexes
+		for (var i = room[copyRoomId].items.length-1; i >= 0; i--) {
+			var targetItem = room[copyRoomId].items[i];
+			if (targetId == "ANY" || targetId == targetItem.id) {
+				if (targetItem.x == copyXPos && targetItem.y == copyYPos) {
+					drawAt("ITM", targetItem.id, pasteXPos, pasteYPos, pasteRoomId);
+				}
+			}
+		}
+	}
+	
+	// If SPR or undefined.
+	if (mapId.toUpperCase() != "TIL" && mapId.toUpperCase() != "ITM") {
+		if (targetId == "ANY") {
+			for (i in sprite) {
+				if (sprite[i].id == "A") {
+					console.log("CAN'T TARGET AVATAR. SKIPPING.");
+				}
+				else if (sprite[i].room == copyRoomId && sprite[i].x == copyXPos && sprite[i].y == copyYPos) {
+					var copyId = sprite[i].id;
+					drawAt("SPR", copyId, pasteXPos, pasteYPos, pasteRoomId);
+				}
+			}
+		}
+		else if (sprite[targetId] != undefined) {
+			if (sprite[targetId] != "A" && sprite[targetId].room == copyRoomId && sprite[targetId].x == copyXPos && sprite[targetId].y == copyYPos) {
+				var copyId = sprite[targetId].id;
+				drawAt("SPR", copyId, pasteXPos, pasteYPos, pasteRoomId);
+			}
+		}
+	}
+}
+
+function copyBoxAt (mapId, targetId, x1, y1, x2, y2, copyRoomId, pasteXPos, pasteYPos, pasteRoomId) {
+	// Trim and sanitize X and Y Positions, and set relative positions if omitted.
+	if (x1 == undefined) {
+		x1 = player().x;
+	}
+	else {
+		x1 = x1.toString().trim();
+		if (x1 == "" ) { x1 = player().x; }
+		else if (x1.includes("+")) { x1 = player().x + parseInt(x1.substring(1)); }
+		else if (x1.includes("-")) { x1 = player().x - parseInt(x1.substring(1)); }
+	}
+	if (x1 < 0 || x1 > 15) {
+		console.log("CLAMPING X1 POSITION. XPOS ("+x1+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		x1 = Math.max(0, Math.min(x1, 15));
+	}
+	// X2
+	if (x2 == undefined) {
+		x2 = player().x;
+	}
+	else {
+		x2 = x2.toString().trim();
+		if (x2 == "" ) { x2 = player().x; }
+		else if (x2.includes("+")) { x2 = player().x + parseInt(x2.substring(1)); }
+		else if (x2.includes("-")) { x2 = player().x - parseInt(x2.substring(1)); }
+	}
+	if (x2 < 0 || x2 > 15) {
+		console.log("CLAMPING X2 POSITION. xPos ("+x2+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		x2 = Math.max(0, Math.min(x2, 15));
+	}
+	// Y1
+	if (y1 == undefined) {
+		y1 = player().y;
+	}
+	else {
+		y1 = y1.toString().trim();
+		if (y1 == "" ) { y1 = player().y; }
+		else if (y1.includes("+")) { y1 = player().y + parseInt(y1.substring(1)); }
+		else if (y1.includes("-")) { y1 = player().y - parseInt(y1.substring(1)); }
+	}
+	if (y1 < 0 || y1 > 15) {
+		console.log("CLAMPING Y1 POSITION. XPOS ("+y1+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		y1 = Math.max(0, Math.min(y1, 15));
+	}
+	// Y2
+	if (y2 == undefined) {
+		y2 = player().y;
+	}
+	else {
+		y2 = y2.toString().trim();
+		if (y2 == "" ) { y2 = player().y; }
+		else if (y2.includes("+")) { y2 = player().y + parseInt(y2.substring(1)); }
+		else if (y2.includes("-")) { y2 = player().y - parseInt(y2.substring(1)); }
+	}
+	if (y2 < 0 || y2 > 15) {
+		console.log("CLAMPING Y2 POSITION. xPos ("+y2+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		y2 = Math.max(0, Math.min(y2, 15));
+	}
+
+	// Trim and sanitize Target Map ID / Type parameter, and use any if not provided.
+	if (mapId == undefined) {
+		//console.log("TARGET TYPE IS UNDEFINED. DEFAULTING TO ANY (TIL, ITM, OR SPR).");
+		mapId = "ANY";
+	}
+	else {
+		mapId = mapId.toString().trim();
+		if (mapId == "" || !(mapId.toUpperCase() == "ANY" || mapId.toUpperCase() == "TIL" || mapId.toUpperCase() == "ITM" || mapId.toUpperCase() == "SPR")) {
+			//console.log("UNEXPECTED TARGET TYPE ("+mapId+"). DEFAULTING TO ANY (TIL, ITM, OR SPR).");
+			mapId = "ANY";
+		}
+	}
+
+	// Trim and sanitize Target ID parameter, and use any if not provided
+	if (targetId == undefined) {
+		//console.log("TARGET ID UNDEFINED. DEFAULTING TO ANY (ANYTHING OF VALID TYPE).");
+		targetId = "ANY";
+	}
+	else {
+		targetId = targetId.toString().trim();
+		if (targetId == "") {
+			//console.log("NO TARGET ID GIVEN. DEFAULTING TO ANY (ANYTHING OF VALID TYPE).");
+			targetId = "ANY";
+		}
+	}
+
+	if (copyRoomId == undefined) {
+		copyRoomId = curRoom;
+	}
+	else {
+		copyRoomId = copyRoomId.toString().trim();
+		if (copyRoomId == "" ) { copyRoomId = curRoom; }
+		else if (room[copyRoomId] == undefined) {
+			console.log("CAN'T COPY. ROOM ID ("+copyRoomId+") NOT FOUND.");
+			return;
+		}
+	}
+
+	// Trim and sanitize Paste Position parameters, and set relative positions, even if omitted.
+	if (pasteXPos == undefined) {
+		pasteXPos = player().x;
+	}
+	else {
+		pasteXPos = pasteXPos.toString().trim();
+		if (pasteXPos == "" ) { pasteXPos = player().x; }
+		else if (pasteXPos.includes("+")) { pasteXPos = player().x + parseInt(pasteXPos.substring(1)); }
+		else if (pasteXPos.includes("-")) { pasteXPos = player().x - parseInt(pasteXPos.substring(1)); }
+	}
+	if (pasteXPos < 0 || pasteXPos > 15) {
+		console.log("CAN'T PASTE. X POSITION ("+pasteXPos+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		return;
+	}
+	else {
+		pasteXPos = parseInt(pasteXPos);
+	}
+
+	if (pasteYPos == undefined) {
+		pasteYPos = player().y;
+	}
+	else {
+		pasteYPos = pasteYPos.toString().trim();
+		if (pasteYPos == "" ) { pasteYPos = player().y; }
+		else if (pasteYPos.includes("+")) { pasteYPos = player().y + parseInt(pasteYPos.substring(1)); }
+		else if (pasteYPos.includes("-")) { pasteYPos = player().y - parseInt(pasteYPos.substring(1)); }
+	}
+	if (pasteYPos < 0 || pasteYPos > 15) {
+		console.log("CAN'T PASTE. Y POSITION ("+pasteYPos+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		return;
+	}
+	else {
+		pasteYPos = parseInt(pasteYPos);
+	}
+	
+	if (pasteRoomId == undefined) {
+		pasteRoomId = curRoom;
+	}
+	else {
+		pasteRoomId = pasteRoomId.toString().trim();
+		if (pasteRoomId == "" ) { pasteRoomId = curRoom; }
+		else if (room[pasteRoomId] == undefined) {
+			console.log("CAN'T PASTE. ROOM ID ("+pasteRoomId+") NOT FOUND.");
+			return;
+		}
+	}
+
+	// Calculate which coordinates are the actual top left and bottom right.
+	var topPos = Math.min(y1, y2);
+	var leftPos = Math.min(x1, x2);
+	var bottomPos = Math.max(y1, y2);
+	var rightPos = Math.max(x1, x2);
+	var copyIds = [];
+	var copyMaps = [];
+	var copyXs = [];
+	var copyYs = [];
+
+	var colId = -1;
+	var rowId = -1;
+
+	// Store maps and ids to copy
+	for (var xPos = leftPos; xPos <= rightPos; xPos++) {
+		colId = -1;
+		rowId++;
+		for (var yPos = topPos; yPos <= bottomPos; yPos++) {
+			colId++;
+			// If TIL or undefined.
+			if (mapId.toUpperCase() != "ITM" && mapId.toUpperCase() != "SPR") {
+				if (targetId == "ANY" || room[copyRoomId].tilemap[yPos][xPos] == targetId) {
+					copyIds.push(room[copyRoomId].tilemap[yPos][xPos]);
+					copyMaps.push("TIL");
+					copyXs.push(pasteXPos+rowId);
+					copyYs.push(pasteYPos+colId);
+				}
+			}
+			
+			// If ITM or undefined.
+			if (mapId.toUpperCase() != "TIL" && mapId.toUpperCase() != "SPR") {
+				// Iterate backwards through items, to prevent issues with removed indexes
+				for (var i = room[copyRoomId].items.length-1; i >= 0; i--) {
+					var targetItem = room[copyRoomId].items[i];
+					if (targetId == "ANY" || targetId == targetItem.id) {
+						if (targetItem.x == xPos && targetItem.y == yPos) {
+							copyIds.push(targetItem.id);
+							copyMaps.push("ITM");
+							copyXs.push(pasteXPos+xPos-1);
+							copyYs.push(pasteYPos+yPos-1);
+						}
+					}
+				}
+			}
+			
+			// If SPR or undefined.
+			if (mapId.toUpperCase() != "TIL" && mapId.toUpperCase() != "ITM") {
+				if (targetId == "ANY") {
+					for (i in sprite) {
+						if (sprite[i].id == "A") {
+							console.log("CAN'T TARGET AVATAR. SKIPPING.");
+						}
+						else if (sprite[i].room == copyRoomId && sprite[i].x == xPos && sprite[i].y == yPos) {
+							copyIds.push(sprite[i].id);
+							copyMaps.push("SPR");
+							copyXs.push(pasteXPos+xPos-1);
+							copyYs.push(pasteYPos+yPos-1);
+						}
+					}
+				}
+				else if (sprite[targetId] != undefined) {
+					if (sprite[targetId] != "A" && sprite[targetId].room == copyRoomId && sprite[targetId].x == xPos && sprite[targetId].y == yPos) {
+						copyIds.push(sprite[i].id);
+						copyMaps.push("SPR");
+						copyXs.push(pasteXPos+xPos-1);
+						copyYs.push(pasteYPos+yPos-1);
+					}
+				}
+			}
+		}
+	}
+
+	// Paste in from copied arrays, at paste position.
+	for (var i = 0; i <= copyIds.length; i++) {
+		drawAt(copyMaps[i], copyIds[i], copyXs[i], copyYs[i], pasteRoomId);
+	}
+}
+
+}(window));

--- a/dist/palette-maps.js
+++ b/dist/palette-maps.js
@@ -1,0 +1,935 @@
+/**
+🎨
+@file palette maps
+@summary allows color pallettes to be defined on a tile-by-tile basis
+@license MIT
+@version 1.0.0
+@requires Bitsy Version: 6.1
+@author Dana Holdampf
+
+@description
+This hack lets you change the color palette, on a tile-by-tile basis.
+Each tile can use a different palette's background, tile, sprite, and extra colors.
+This can also recolor sprites, changing their palette as they move through a recolored tile.
+
+HOW TO USE:
+1. Copy-paste this script into a script tag after the bitsy source
+2. Edit hackOptions below, as needed
+
+You can use this hack in 3 main ways:
+=====================================
+First, you can define a Palette Map for any room, in the hackOptions below.
+- A Palette Map is a 16-by-16 grid of Palette IDs, separated by commas.
+- This corresponds to what palette each location in that room will be drawn with.
+- The Palette Map will override the room's default background, tile color, sprite color, etc.
+- Values in the Palette Map correspond to the Palette IDs in your Game Data (0, 1, a, etc.).
+- The value "-", or other undefined Palette IDs, will draw using the room's default palette.
+- NOTE: The Palette Map recolors everything, including Sprites and Items drawn at that position.
+
+Second, you can put a Palette Override Tag in the name of any tile, sprite, or item.
+- By default, this tag is #PAL0, #PAL1, #PALa, etc., but this can be changed below.
+- This causes that graphic to always be drawn in the specified Palette's colors.
+- Set prioritizePaletteTag to false in the options, to not have tags override a Palette Map.
+
+Third, you can use included dialog commands, to modify the palette of a room or tile.
+- NOTE: If you know JS, you can also use the JavaScript Dialog Hack to modify palettes.
+
+-- SETTING ROOM'S DEFAULT PALETTE ------------------------------
+
+{palette "id, room"}
+{paletteNow "id, room"}
+
+Information:
+- Sets default palette of a room, without changing it's Palette Map.
+- This is the normal room palette set in the editor, used by tiles with undefined or empty palette ids.
+
+Parameters:
+- id:	The id (letter/number) of the color palette, which will be used as the room's new default palette.
+		See the Game Data tab to reference color palette IDs
+- room:	The id (number/letter) of the room you're editing the palette map for.
+		Leave blank to modify the room the player is currently in.
+
+-- SETTING PALETTE OF A SPECIFIC TILE --------------------------
+
+{tilePalette "id, x, y, room"}
+{tilePaletteNow "id, x, y, room"}
+
+Information:
+- Changes palette used at a coordinate in a room's Palette Map.
+- The Palette Map affects all tiles, items, or sprites at that location.
+
+Parameters:
+- id:	The id (number/letter) of the color palette, which will override the palette used at a given position.
+		Leave this blank to reset a tile's palette, and revert to the room's palette (still include commas).
+		See the Game Data tab to reference color palette IDs
+- x, y:	The x and y coordinates of the target tile you want to change the palette of, from 0-15.
+		Put + or - before a coordinate to target tiles relative to the player's position. (ex. +10, -2).
+		Leave X or Y blank (or use +0) to use the player's current position.
+- room:	The id (number/letter) of the room you're editing the palette map for.
+		Leave blank to modify the room the player is currently in.
+
+-- RESETTING THE PALETTE OF ALL TILES IN A ROOM ----------------
+
+{resetTilePalette "room"}
+{resetTilePaletteNow "room"}
+
+Information:
+- Resets the Palette Map of a room back to the values it had to start.
+- If the room had no default Palette Map defined in the Hack Options, tiles will be set to none.
+
+Parameters:
+- room:	The id (number/letter) of the room you're resetting the palette map for.
+		Leave blank to modify the room the player is currently in.
+
+-- CLEARS THE PALETTE MAP FOR ALL TILES IN A ROOM -------------
+
+{clearTilePalette "roomId"} 
+{clearTilePaletteNow "roomId"}
+
+Information:
+- clears Palette Map data for a room, so all tiles use the room's default.
+
+Parameters:
+- room:	The id (number/letter) of the room you're resetting the palette map for.
+		Leave blank to modify the room the player is currently in.
+
+NOTE: add Now to any command to trigger it mid-dialog. (roomPalNow, tilePalNow, clearPalNow, resetPalNow)
+
+Examples:
+{palette "a,0"} sets the default palette for Room 0 to Palette a, once the dialog is done.
+{paletteNow "2"} immediately sets the default palette for the current room to Palette 2.
+{tilePalette "0,2,4"} sets the Palette Map at coordinates 0,2 in the current room to Palette 0.
+{tilePaletteNow "z,0,0,13"} mid-dialog, sets the Palette Map at 0,0 in Room 13 to use Palette z.
+{resetPalette "4"} resets Room 4's Palette Map to the palette IDs it had when the game started.
+{resetPaletteNow} immediately resets the current room's Palette Map to the value it had at the start.
+{clearPalette} removes Palette Map at all coordinates in the current room, so they use the default palette.
+{clearPaletteNow "a1"} instantly clears Palette Map for Room a1, so all tiles show the default palette.
+
+This hack is designed to be flexible. Here are some ideas for how to use it!
+============================================================================
+- By switching palettes from tile to tile, you can effectively use 2 unique colors per tile.
+- You can palette-swap, allowing you to reuse the same tile or item in many colors.
+- You can recolor areas for visual effects, like differently-lit, smokey, or underwater tiles.
+- Using the dialog tags (or JavaScript) you can recolor an area without needing duplicate rooms.
+*/
+this.hacks = this.hacks || {};
+(function (exports, bitsy) {
+'use strict';
+var hackOptions = {
+	paletteTag: '#PAL',
+	// Add this flag to Tile/Sprite/Item Name, followed by a Palette ID (#PAL0, #PALa, etc.)
+	// This tile, sprite, or item will automatically be drawn with that palette.
+	// By default, this will override the room's default palette and the tile palette map.
+	
+	prioritizePaletteTag: true,
+	// Whether the Palette Tag above takes priority over a room's Palette Map, when recoloring a graphic.
+	// If true, Tile/Sprite/Item always uses the palette defined by it's Palette Tag, ignoring Palette Maps.
+	// If false, Tile/Sprite/Item's palette is overridden by a room's Palette Map (whenever not default/"-").
+	
+	paletteMapDefinitions: {
+	// You can define a Palette Map for any room here. Just copy or edit an element from this list.
+	// Each row is a string of Palette IDs, separated by commas. These match the coordinates in the Room.
+	// The Palette IDs in the grid are used to draw Tiles/Sprites/Items, instead of the room's default palette.
+	// The IDs in the Palette Map match the Palette IDs in your Game Data (0, 1, a, z, etc.)
+	// "-", or any ID that doesn't match a Palette ID, use the room's default palette.
+		
+		// This is a blank Palette Map for Room ID 0. It can be edited, copied, or removed.
+		0: [
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+		],
+		// This is a sample Palette Map for Room ID 100. It can be edited, copied, or removed.
+		100: [
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,1,0,0,0,0,1,1,1,1,0,0,0,0,1,-",
+			"-,0,-,-,-,-,-,-,-,-,-,-,-,-,0,-",
+			"-,0,-,-,-,-,-,-,-,-,-,-,-,-,0,-",
+			"-,0,-,-,1,1,0,0,1,1,0,0,-,-,0,-",
+			"-,0,-,-,1,1,0,0,1,1,0,0,-,-,0,-",
+			"-,2,-,-,0,0,1,1,0,0,1,1,-,-,2,-",
+			"-,2,-,-,0,0,1,1,0,0,1,1,-,-,2,-",
+			"-,2,-,-,1,1,0,0,1,1,0,0,-,-,2,-",
+			"-,2,-,-,1,1,0,0,1,1,0,0,-,-,2,-",
+			"-,0,-,-,0,0,1,1,0,0,1,1,-,-,0,-",
+			"-,0,-,-,0,0,1,1,0,0,1,1,-,-,0,-",
+			"-,0,-,-,-,-,-,-,-,-,-,-,-,-,0,-",
+			"-,0,-,-,-,-,-,-,-,-,-,-,-,-,0,-",
+			"-,1,0,0,0,0,3,3,3,3,0,0,0,0,1,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+		],
+		// This is a blank Palette Map for Room ID ZZZ. It can be edited, copied, or removed.
+		ZZZ: [
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+		],
+	},
+};
+
+bitsy = bitsy && bitsy.hasOwnProperty('default') ? bitsy['default'] : bitsy;
+
+/**
+@file utils
+@summary miscellaneous bitsy utilities
+@author Sean S. LeBlanc
+*/
+
+/*
+Helper used to replace code in a script tag based on a search regex
+To inject code without erasing original string, using capturing groups; e.g.
+	inject(/(some string)/,'injected before $1 injected after')
+*/
+function inject(searchRegex, replaceString) {
+	// find the relevant script tag
+	var scriptTags = document.getElementsByTagName('script');
+	var scriptTag;
+	var code;
+	for (var i = 0; i < scriptTags.length; ++i) {
+		scriptTag = scriptTags[i];
+		var matchesSearch = scriptTag.textContent.search(searchRegex) !== -1;
+		var isCurrentScript = scriptTag === document.currentScript;
+		if (matchesSearch && !isCurrentScript) {
+			code = scriptTag.textContent;
+			break;
+		}
+	}
+
+	// error-handling
+	if (!code) {
+		throw 'Couldn\'t find "' + searchRegex + '" in script tags';
+	}
+
+	// modify the content
+	code = code.replace(searchRegex, replaceString);
+
+	// replace the old script tag with a new one using our modified code
+	var newScriptTag = document.createElement('script');
+	newScriptTag.textContent = code;
+	scriptTag.insertAdjacentElement('afterend', newScriptTag);
+	scriptTag.remove();
+}
+
+/**
+ * Helper for getting an array with unique elements 
+ * @param  {Array} array Original array
+ * @return {Array}       Copy of array, excluding duplicates
+ */
+function unique(array) {
+	return array.filter(function (item, idx) {
+		return array.indexOf(item) === idx;
+	});
+}
+
+/**
+
+@file kitsy-script-toolkit
+@summary makes it easier and cleaner to run code before and after Bitsy functions or to inject new code into Bitsy script tags
+@license WTFPL (do WTF you want)
+@version 4.0.1
+@requires Bitsy Version: 4.5, 4.6
+@author @mildmojo
+
+@description
+HOW TO USE:
+  import {before, after, inject, addDialogTag, addDeferredDialogTag} from "./helpers/kitsy-script-toolkit";
+
+  before(targetFuncName, beforeFn);
+  after(targetFuncName, afterFn);
+  inject(searchRegex, replaceString);
+  addDialogTag(tagName, dialogFn);
+  addDeferredDialogTag(tagName, dialogFn);
+
+  For more info, see the documentation at:
+  https://github.com/seleb/bitsy-hacks/wiki/Coding-with-kitsy
+*/
+
+
+// Ex: inject(/(names.sprite.set\( name, id \);)/, '$1console.dir(names)');
+function inject$1(searchRegex, replaceString) {
+	var kitsy = kitsyInit();
+	kitsy.queuedInjectScripts.push({
+		searchRegex: searchRegex,
+		replaceString: replaceString
+	});
+}
+
+// Ex: before('load_game', function run() { alert('Loading!'); });
+//     before('show_text', function run(text) { return text.toUpperCase(); });
+//     before('show_text', function run(text, done) { done(text.toUpperCase()); });
+function before(targetFuncName, beforeFn) {
+	var kitsy = kitsyInit();
+	kitsy.queuedBeforeScripts[targetFuncName] = kitsy.queuedBeforeScripts[targetFuncName] || [];
+	kitsy.queuedBeforeScripts[targetFuncName].push(beforeFn);
+}
+
+// Ex: after('load_game', function run() { alert('Loaded!'); });
+function after(targetFuncName, afterFn) {
+	var kitsy = kitsyInit();
+	kitsy.queuedAfterScripts[targetFuncName] = kitsy.queuedAfterScripts[targetFuncName] || [];
+	kitsy.queuedAfterScripts[targetFuncName].push(afterFn);
+}
+
+function kitsyInit() {
+	// return already-initialized kitsy
+	if (bitsy.kitsy) {
+		return bitsy.kitsy;
+	}
+
+	// Initialize kitsy
+	bitsy.kitsy = {
+		queuedInjectScripts: [],
+		queuedBeforeScripts: {},
+		queuedAfterScripts: {}
+	};
+
+	var oldStartFunc = bitsy.startExportedGame;
+	bitsy.startExportedGame = function doAllInjections() {
+		// Only do this once.
+		bitsy.startExportedGame = oldStartFunc;
+
+		// Rewrite scripts and hook everything up.
+		doInjects();
+		applyAllHooks();
+
+		// Start the game
+		bitsy.startExportedGame.apply(this, arguments);
+	};
+
+	return bitsy.kitsy;
+}
+
+
+function doInjects() {
+	bitsy.kitsy.queuedInjectScripts.forEach(function (injectScript) {
+		inject(injectScript.searchRegex, injectScript.replaceString);
+	});
+	_reinitEngine();
+}
+
+function applyAllHooks() {
+	var allHooks = unique(Object.keys(bitsy.kitsy.queuedBeforeScripts).concat(Object.keys(bitsy.kitsy.queuedAfterScripts)));
+	allHooks.forEach(applyHook);
+}
+
+function applyHook(functionName) {
+	var functionNameSegments = functionName.split('.');
+	var obj = bitsy;
+	while (functionNameSegments.length > 1) {
+		obj = obj[functionNameSegments.shift()];
+	}
+	var lastSegment = functionNameSegments[0];
+	var superFn = obj[lastSegment];
+	var superFnLength = superFn ? superFn.length : 0;
+	var functions = [];
+	// start with befores
+	functions = functions.concat(bitsy.kitsy.queuedBeforeScripts[functionName] || []);
+	// then original
+	if (superFn) {
+		functions.push(superFn);
+	}
+	// then afters
+	functions = functions.concat(bitsy.kitsy.queuedAfterScripts[functionName] || []);
+
+	// overwrite original with one which will call each in order
+	obj[lastSegment] = function () {
+		var returnVal;
+		var args = [].slice.call(arguments);
+		var i = 0;
+
+		function runBefore() {
+			// All outta functions? Finish
+			if (i === functions.length) {
+				return returnVal;
+			}
+
+			// Update args if provided.
+			if (arguments.length > 0) {
+				args = [].slice.call(arguments);
+			}
+
+			if (functions[i].length > superFnLength) {
+				// Assume funcs that accept more args than the original are
+				// async and accept a callback as an additional argument.
+				return functions[i++].apply(this, args.concat(runBefore.bind(this)));
+			} else {
+				// run synchronously
+				returnVal = functions[i++].apply(this, args);
+				if (returnVal && returnVal.length) {
+					args = returnVal;
+				}
+				return runBefore.apply(this, args);
+			}
+		}
+
+		return runBefore.apply(this, arguments);
+	};
+}
+
+function _reinitEngine() {
+	// recreate the script and dialog objects so that they'll be
+	// referencing the code with injections instead of the original
+	bitsy.scriptModule = new bitsy.Script();
+	bitsy.scriptInterpreter = bitsy.scriptModule.CreateInterpreter();
+
+	bitsy.dialogModule = new bitsy.Dialog();
+	bitsy.dialogRenderer = bitsy.dialogModule.CreateRenderer();
+	bitsy.dialogBuffer = bitsy.dialogModule.CreateBuffer();
+}
+
+// Rewrite custom functions' parentheses to curly braces for Bitsy's
+// interpreter. Unescape escaped parentheticals, too.
+function convertDialogTags(input, tag) {
+	return input
+		.replace(new RegExp('\\\\?\\((' + tag + '(\\s+(".+?"|.+?))?)\\\\?\\)', 'g'), function (match, group) {
+			if (match.substr(0, 1) === '\\') {
+				return '(' + group + ')'; // Rewrite \(tag "..."|...\) to (tag "..."|...)
+			}
+			return '{' + group + '}'; // Rewrite (tag "..."|...) to {tag "..."|...}
+		});
+}
+
+
+function addDialogFunction(tag, fn) {
+	var kitsy = kitsyInit();
+	kitsy.dialogFunctions = kitsy.dialogFunctions || {};
+	if (kitsy.dialogFunctions[tag]) {
+		throw new Error('The dialog function "' + tag + '" already exists.');
+	}
+
+	// Hook into game load and rewrite custom functions in game data to Bitsy format.
+	before('parseWorld', function (game_data) {
+		return [convertDialogTags(game_data, tag)];
+	});
+
+	kitsy.dialogFunctions[tag] = fn;
+}
+
+/**
+ * Adds a custom dialog tag which executes the provided function.
+ * For ease-of-use with the bitsy editor, tags can be written as
+ * (tagname "parameters") in addition to the standard {tagname "parameters"}
+ * 
+ * Function is executed immediately when the tag is reached.
+ *
+ * @param {string}   tag Name of tag
+ * @param {Function} fn  Function to execute, with signature `function(environment, parameters, onReturn){}`
+ *                       environment: provides access to SetVariable/GetVariable (among other things, see Environment in the bitsy source for more info)
+ *                       parameters: array containing parameters as string in first element (i.e. `parameters[0]`)
+ *                       onReturn: function to call with return value (just call `onReturn(null);` at the end of your function if your tag doesn't interact with the logic system)
+ */
+function addDialogTag(tag, fn) {
+	addDialogFunction(tag, fn);
+	inject$1(
+		/(var functionMap = new Map\(\);)/,
+		'$1functionMap.set("' + tag + '", kitsy.dialogFunctions.' + tag + ');'
+	);
+}
+
+/**
+ * Adds a custom dialog tag which executes the provided function.
+ * For ease-of-use with the bitsy editor, tags can be written as
+ * (tagname "parameters") in addition to the standard {tagname "parameters"}
+ * 
+ * Function is executed after the dialog box.
+ *
+ * @param {string}   tag Name of tag
+ * @param {Function} fn  Function to execute, with signature `function(environment, parameters){}`
+ *                       environment: provides access to SetVariable/GetVariable (among other things, see Environment in the bitsy source for more info)
+ *                       parameters: array containing parameters as string in first element (i.e. `parameters[0]`)
+ */
+function addDeferredDialogTag(tag, fn) {
+	addDialogFunction(tag, fn);
+	bitsy.kitsy.deferredDialogFunctions = bitsy.kitsy.deferredDialogFunctions || {};
+	var deferred = bitsy.kitsy.deferredDialogFunctions[tag] = [];
+	inject$1(
+		/(var functionMap = new Map\(\);)/,
+		'$1functionMap.set("' + tag + '", function(e, p, o){ kitsy.deferredDialogFunctions.' + tag + '.push({e:e,p:p}); o(null); });'
+	);
+	// Hook into the dialog finish event and execute the actual function
+	after('onExitDialog', function () {
+		while (deferred.length) {
+			var args = deferred.shift();
+			bitsy.kitsy.dialogFunctions[tag](args.e, args.p, args.o);
+		}
+	});
+	// Hook into the game reset and make sure data gets cleared
+	after('clearGameData', function () {
+		deferred.length = 0;
+	});
+}
+
+
+
+// Once world is parsed, parse the Palette Map data
+after("parseWorld", function() {
+	parsePaletteMaps();
+});
+
+// Do a second pass after drawRoom, to overdraw any tiles that aren't the default palette
+after("drawRoom", function(room,context,frameIndex) {
+	overdrawRecoloredTiles(room,context,frameIndex);
+});
+
+// Implement tags to set a room's Default Palette
+addDialogTag('paletteNow', function (environment, parameters, onReturn) {
+	var params = parameters[0].split(',');
+	setRoomPalette(params[0],params[1]);
+	onReturn(null);
+});
+addDeferredDialogTag('palette', function (environment, parameters) {
+	var params = parameters[0].split(',');
+	setRoomPalette(params[0],params[1]);
+});
+
+// Implement tags to modify a room's Palette Map
+addDialogTag('tilePaletteNow', function (environment, parameters, onReturn) {
+	var params = parameters[0].split(',');
+	setPaletteAt(params[0],params[1],params[2],params[3]);	
+	onReturn(null);
+});
+addDeferredDialogTag('tilePalette', function (environment, parameters) {
+	var params = parameters[0].split(',');
+	setPaletteAt(params[0],params[1],params[2],params[3]);	
+});
+
+// Implement tags to delete a room's Palette Map
+addDialogTag('clearTilePaletteNow', function (environment, parameters, onReturn) {
+	clearPaletteMap(parameters[0]);
+	onReturn(null);
+});
+addDeferredDialogTag('clearTilePalette', function (environment, parameters) {
+	clearPaletteMap(parameters[0]);
+});
+
+// Implement tags to set a reset a room's Palette Map to starting values
+addDialogTag('resetTilePaletteNow', function (environment, parameters, onReturn) {
+	resetPaletteMap(parameters[0]);
+	onReturn(null);
+});
+addDeferredDialogTag('resetTilePalette', function (environment, parameters) {
+	resetPaletteMap(parameters[0]);
+});
+
+
+
+// The "default" Palette Map is applied to all rooms that don't have a Palette Map defined.
+// Normally each coordinate is set to use the Room's Default Palette using "-", but this can be edited.
+// These Palette Maps can be accessed via JS using "paletteMap.roomId[y/row][x/column]"
+var paletteMap = {
+	default: [
+		["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+	]
+};
+
+function isPaletteOverridden (drawing) {
+
+	// Checks if tile/sprite/item's name contains the Palette Override Tag
+	if (drawing.name) {
+		var paletteId = drawing.name.indexOf(hackOptions.paletteTag);
+		if (paletteId != -1) {
+			var p = drawing.name[paletteId+hackOptions.paletteTag.length];
+
+			// returns single digit/character after palette tag, if a valid palette
+			if (palette[p] != undefined) {
+				return p;
+			}
+		}
+		return false; //if palette tag isn't present, returns default character
+	}
+}
+
+// TODO: If it's useful, replace this with a function to set every element of a Palette Map to an ID?
+function clearPaletteMap(roomId) {
+	// Trim and sanitize Room ID parameter, and set to current room if omitted
+	if (roomId == undefined) {
+		roomId = curRoom;
+		//roomId = getRoom().id;
+	}
+	else {
+		roomId = roomId.toString().trim();
+		if (roomId == "" ) { roomId = curRoom; }
+		else if (room[roomId] == undefined) {
+			console.log("CAN'T GET ROOM. ROOM ID ("+roomId+") NOT FOUND.");
+			return;
+		}
+	}
+
+	if (roomId.toLowerCase() == "default") {
+		roomId = "default";
+	}
+	console.log("CLEARING PALETTE MAP FOR ROOM " + roomId);
+
+	paletteMap[roomId] = [
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		];
+}
+
+
+function resetPaletteMap(roomId) {
+	// Trim and sanitize Room ID parameter, and set to current room if omitted
+	if (roomId == undefined) {
+		roomId = curRoom;
+		//roomId = getRoom().id;
+	}
+	else {
+		roomId = roomId.toString().trim();
+		if (roomId == "" ) { roomId = curRoom; }
+		else if (room[roomId] == undefined) {
+			console.log("CAN'T GET ROOM. ROOM ID ("+roomId+") NOT FOUND.");
+			return;
+		}
+	}
+	console.log("RESETTING PALETTE MAP FOR ROOM " + roomId);
+
+	// If given the Default parameter, resets the Default Map, and Returns.
+	if (roomId.toLowerCase() == "default") {
+		paletteMap["default"] = [
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		];
+		return true;
+	}
+
+	// If it isn't the Default map, Deep Clone a new Palette Map object from it.
+	paletteMap[roomId] = JSON.parse(JSON.stringify(paletteMap["default"])); // Deep Clone the Default object.
+	
+	// If Palette Map for current Room exists in Hack Options, overwrite the new map with this data.
+	if (hackOptions.paletteMapDefinitions[roomId] != undefined) {
+		var newPaletteData = hackOptions.paletteMapDefinitions[roomId];
+
+		newPaletteData.forEach(function (palRow, r) {
+			var palRowArray = palRow.split(",");
+
+			if (palRowArray != undefined) {
+				for (var c = 0; c < palRowArray.length; c++) {
+					
+					// If Palette ID exists and matches a valid Palette, write it.
+					if (palRowArray[c] != undefined && palette[ palRowArray[c] ] != undefined ) {
+						paletteMap[roomId][r][c] = palRowArray[c];
+					}
+					else {
+						paletteMap[roomId][r][c] = "-";
+					}
+				}	
+			}
+		});
+	}
+}
+
+function parsePaletteMaps() {
+	console.log("PARSING PALETTE MAPS");
+
+	for (id in room) { // Initialize Palette Maps for each Room
+		resetPaletteMap(id);
+	}
+}
+
+function setPaletteAt(p,x,y,roomId) {
+	// Trim and sanitize X Position parameter, and set relative positions, even if omitted.
+	if (x == undefined) {
+		x = player().x;
+	}
+	else {
+		x = x.toString().trim();
+		if (x == "" ) { x = player().x; }
+		else if (x.includes("+")) { x = player().x + parseInt(x.substring(1)); }
+		else if (x.includes("-")) { x = player().x - parseInt(x.substring(1)); }
+	}
+	if (x < 0 || x > 15) {
+		console.log("CAN'T SET PALETTE. X POSITION ("+x+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		return;
+	}
+
+	// Trim and sanitize Y Position parameter, and set relative positions, even if omitted
+	if (y == undefined) {
+		y = player().y;
+	}
+	else {
+		y = y.toString().trim();
+		if (y == "" ) { y = player().y; }
+		else if (y.includes("+")) { y = player().y + parseInt(y.substring(1)); }
+		else if (y.includes("-")) { y = player().y - parseInt(y.substring(1)); }
+	}
+	if (y < 0 || y > 15) {
+		console.log("CAN'T SET PALETTE. Y POSITION ("+y+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		return;
+	}
+
+	// Trim and sanitize Room ID parameter, and set to current room if omitted
+	if (roomId == undefined) {
+		roomId = curRoom;
+		//roomId = getRoom().id;
+	}
+	else {
+		roomId = roomId.toString().trim();
+		if (roomId == "" ) { roomId = curRoom; }
+		else if (room[roomId] == undefined) {
+			console.log("CAN'T GET ROOM. ROOM ID ("+roomId+") NOT FOUND.");
+			return;
+		}
+	}
+
+	if (p == undefined) {
+		p = "-";
+	}
+	else if (palette[p] == undefined) {
+		p = "-";
+	}
+	console.log("SET PALETTE AT " + x + "," + y + "(ROOM " + roomId + ") TO " + p);
+	paletteMap[roomId][y][x] = p;
+}
+
+function setRoomPalette (p, roomId) {
+	// Trim and sanitize Room ID parameter, and set to current room if omitted
+	if (roomId == undefined) {
+		roomId = curRoom;
+		//roomId = getRoom().id;
+	}
+	else {
+		roomId = roomId.toString().trim();
+		if (roomId == "" ) { roomId = curRoom; }
+		else if (room[roomId] == undefined) {
+			console.log("CAN'T SET ROOM PALETTE. ROOM ID ("+roomId+") NOT FOUND.");
+			return;
+		}
+	}
+
+	if (p == undefined) {
+		p = "-";
+	}
+	else if (palette[p] == undefined) {
+		p = "-";
+	}
+
+	// If given Palette ID matches an existing Palette, set room palette to that
+	if (palette[p] != undefined ) {
+		console.log("ROOM " + roomId + " DEFAULT PALETTE SET TO " + p);
+		room[roomId].pal = p;
+		return true;
+	}
+	console.log("ROOM " + roomId + " DEFAULT PALETTE CAN'T BE SET TO " + p + "; INVALID PALETTE ID");
+	return false;
+}
+
+function getPaletteAt(x,y,roomId) {
+	// Trim and sanitize X Position parameter, and set relative positions, even if omitted.
+	if (x == undefined) {
+		x = player().x;
+	}
+	else {
+		x = x.toString().trim();
+		if (x == "" ) { x = player().x; }
+		else if (x.includes("+")) { x = player().x + parseInt(x.substring(1)); }
+		else if (x.includes("-")) { x = player().x - parseInt(x.substring(1)); }
+	}
+	if (x < 0 || x > 15) {
+		console.log("CAN'T GET PALETTE. X POSITION ("+x+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		return;
+	}
+
+	// Trim and sanitize Y Position parameter, and set relative positions, even if omitted
+	if (y == undefined) {
+		y = player().y;
+	}
+	else {
+		y = y.toString().trim();
+		if (y == "" ) { y = player().y; }
+		else if (y.includes("+")) { y = player().y + parseInt(y.substring(1)); }
+		else if (y.includes("-")) { y = player().y - parseInt(y.substring(1)); }
+	}
+	if (y < 0 || y > 15) {
+		console.log("CAN'T GET PALETTE. Y POSITION ("+y+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		return;
+	}
+
+	// Trim and sanitize Room ID parameter, and set to current room if omitted
+	if (roomId == undefined) {
+		roomId = curRoom;
+	}
+	else {
+		roomId = roomId.toString().trim();
+		if (roomId == "" ) { roomId = curRoom; }
+		else if (room[roomId] == undefined) {
+			console.log("CAN'T GET ROOM. ROOM ID ("+roomId+") NOT FOUND.");
+			return;
+		}
+	}
+
+	//if (roomId == undefined || room[roomId] == undefined) {
+	//	roomId = getRoom().id;
+	//}
+
+	// Check for Palette Map for the room, if it exists.
+	var p = -1;
+	if (paletteMap[roomId] != undefined) {
+		p = paletteMap[roomId][y][x];
+	}
+
+	// Check for Palette Map for the room, if it exists. Defaults to -1 if undefined.	
+	if (palette[p] == undefined) {
+		p = getRoom().pal;
+	}
+	return p;
+}
+
+function overdrawRecoloredTiles(room,context,frameIndex) {
+	if (!context) { //optional pass in context;
+		context = ctx;
+	}
+	var paletteId = "default";
+
+	// protect against invalid rooms
+	if (room === undefined) {
+		return;
+	}
+	// set default paletteId to room's palette
+	if (room.pal != null && palette[paletteId] != undefined) {
+		paletteId = room.pal;
+	}
+
+	// calculate tile dimensions for drawing recolored backgrounds on empty tiles
+	var tileWidth = canvas.width/16;
+	var tileHeight = canvas.height/16;
+
+	//overdraw any recolored tiles on top of existing room
+	for (var r in room.tilemap) {
+		for (var c in room.tilemap[r]) {
+			
+			var tileTop = r*tileHeight;
+			var tileLeft = c*tileWidth;
+			var tilePaletteId = getPaletteAt(c,r);
+			
+			// skip drawing tile, if it's invalid or already been drawn in default color
+			if (palette[tilePaletteId] != undefined || palette[tilePaletteId] != paletteId) {
+				
+				//draw backgrounds as colored rectangles
+				context.fillStyle = "rgb(" + getPal(tilePaletteId)[0][0] + "," + getPal(tilePaletteId)[0][1] + "," + getPal(tilePaletteId)[0][2] + ")";
+				context.fillRect(tileLeft, tileTop, tileLeft+tileWidth, tileTop+tileHeight);
+
+				var id = room.tilemap[r][c];
+				if (id != "0") {
+					if (tile[id] != null) {
+						// If a tile has the #PAL tag, it overrides the tile's normal palette.
+						if (hackOptions.prioritizePaletteTag) {
+							var paletteOverrideId = isPaletteOverridden(tile[room.tilemap[r][c]]);
+							if (paletteOverrideId) {
+								var tilePaletteId = paletteOverrideId;
+							}
+						}
+						drawTile( getTileImage(tile[id],tilePaletteId,frameIndex), c, r, context );
+					}
+				}				
+			}
+		}
+	}
+
+	//draw items
+	for (var i = 0; i < room.items.length; i++) {
+		var itm = room.items[i];
+
+		var itemPaletteId = getPaletteAt(itm.x,itm.y);
+		if (palette[itemPaletteId] != undefined || palette[itemPaletteId] != paletteId) {
+			if (hackOptions.prioritizePaletteTag) {
+				var paletteOverrideId = isPaletteOverridden(item[itm.id]);
+				if (paletteOverrideId) {
+					itemPaletteId = paletteOverrideId;
+				}
+			}
+			drawItem( getItemImage(item[itm.id],itemPaletteId,frameIndex), itm.x, itm.y, context );		
+		}
+	}
+
+	//draw sprites
+	for (id in sprite) {
+		var spr = sprite[id];
+		if (spr.room === room.id) {
+
+			// Get palette map at sprite's coordinate
+			var spritePaletteId = getPaletteAt(spr.x,spr.y);
+			if (palette[spritePaletteId] != undefined || palette[spritePaletteId] != paletteId) {
+				if (hackOptions.prioritizePaletteTag) {
+					var paletteOverrideId = isPaletteOverridden(spr);
+					if (paletteOverrideId) {
+						spritePaletteId = paletteOverrideId;
+					}
+				}
+			}
+			drawSprite( getSpriteImage(spr,spritePaletteId,frameIndex), spr.x, spr.y, context );
+		}
+	}
+}
+
+exports.hackOptions = hackOptions;
+
+}(this.hacks.palette_maps = this.hacks.palette_maps || {}, window));

--- a/dist/textbox-styler.js
+++ b/dist/textbox-styler.js
@@ -1,7 +1,7 @@
 /**
 📐
 @file textbox styler
-@summary 
+@summary customize the style and properties of the textbox
 @license MIT
 @version 1.0.0
 @requires Bitsy Version: 6.1

--- a/dist/textbox-styler.js
+++ b/dist/textbox-styler.js
@@ -1,0 +1,1498 @@
+/**
+📐
+@file textbox styler
+@summary 
+@license MIT
+@version 1.0.0
+@requires Bitsy Version: 6.1
+@author Dana Holdampf & Sean S. LeBlanc
+
+@description
+This hack lets you edit the appearance, position, and other properties of the textbox.
+It lets you draw a border, replace the continue arrow, resize or reposition the box, recolor text or backgrounds, etc.
+You can also use dialog tags to switch styles, or redefine style properties, from a dialog.
+
+NOTE: This hack re-implements the functionality of the Long Dialog hack.
+Since they modify the same code, don't use them both to avoid conflicts!
+Like the Long Dialog hack, it also includes the paragraph break "(p)" dialog tag.
+
+HOW TO USE:
+1. Copy-paste this script into a script tag after the bitsy source
+2. Edit hackOptions below, to define the default textbox style
+3. Optionally, add additional alternate styles to the dialogStyles section
+
+You can define custom style properties for the textbox in the hackOptions below.
+- The topmost options are the default style properties, which are applied to the textbox initially.
+- The dialogStyles section is used for defining alternate styles you can switch between.
+- Use the dialog commands below to switch between styles, or change individual properties.
+
+The Dialog Tags for switching textbox styles are as follows:
+============================================================
+
+-- SWITCH TEXTBOX STYLE, WITH UNDEFINED PROPERTIES BEING IGNORED ---------------
+
+{textStyle "dialogStyle"}
+{textStyleNow "dialogStyle"}
+
+Information:
+- Replaces current textbox style with a new set of style properties, as defined in the dialogStyles below.
+- Only changes style properties that are defined in the dialogStyle. Undefined properties are left unchanged.
+
+Parameters:
+- dialogStyle:	id/name of a dialogStyle, as defined in the hackOptions below. (ex. "vanilla", "centered", "inverted", etc.)
+
+-- SWITCH TEXTBOX STYLE, WITH UNDEFINED PROPERTIES REVERTING TO DEFAULTS -------
+
+{setTextStyle "dialogStyle"}
+{setTextStyleNow "dialogStyle"}
+
+Information:
+- As above, but any undefined style properties in the new dialogStyle revert to the default style properties.
+
+Parameters:
+- dialogStyle:	id/name of a dialog style, as defined in the hackOptions below. (ex. "vanilla", "centered", "inverted", etc.)
+
+-- CHANGE AN INDIVIDUAL TEXTBOX STYLE PROPERTY ---------------------------------
+
+{textProperty "styleProperty, styleValue"}
+{textPropertyNow "styleProperty, styleValue"}
+
+Information:
+- Sets an individual textbox style property, to a given value. See the hackOptions below for valid properties and values.
+
+Parameters:
+- styleProperty:	id/name of a style property, as defined in the hackOptions below. (ex. "borderColor", "textboxWidth", "textSpeed", etc.)
+- styleValue:		value to assign to the styleProperty, as defined in the hackOptions below. (ex. "[128,128,128,256]", "140", etc.)
+
+-- REVERT TEXTBOX STYLE TO THE DEFAULT STYLE -----------------------------------
+
+{resetTextStyle}
+{resetTextStyleNow}
+
+Information:
+- Resets all style properties to the values in the default dialog style, as defined in the hackOptions below.
+
+-- REVERT AN INDIVIDUAL TEXTBOX STYLE PROPERTY TO IT'S DEFAULT VALUE -----------
+
+{resetProperty "styleProperty"}
+{resetPropertyNow "styleProperty"}
+
+Information:
+- Resets an individual style property to it's default value, as defined in the hackOptions below.
+
+Parameters:
+- styleProperty:	id/name of a style property, as defined in the hackOptions below. (ex. "borderColor", "textboxWidth", "textSpeed", etc.)
+
+-- SET OR MODIFY THE POSITION AND SIZE OF THE TEXTBOX TO AN ABSOLUTE VALUE -----
+
+{textPosition "x, y, width, minLines, maxLines"}
+{textPositionNow "x, y, width, minLines, maxLines"}
+
+Information:
+- Repositions and resizes the textbox, at an absolute position based on parameters.
+- Calculates the necessary style properties and spacing for the textbox automatically.
+
+Parameters:
+- x, y:			The x and y coordinates of the top left corner. Measured in bitsy-scale pixels (0-128).
+- width:		The width of the textbox. Measured in bitsy-scale pixels (0-128).
+- minLines: 	The minimum number of lines to display on the textbox. Height resizes automatically.
+- maxLines: 	The maximum number of lines to display on the textbox. Height resizes automatically.
+				If any parameter is left blank, the textbox will use it's current values.
+				If given a +/- value (+8, -40, etc) that value is adjusted relative to it's current value.
+
+----------------------------------------------------------------
+
+DIALOG TAG NOTES:
+- Add "Now" to the end of these dialog tags to make the tag trigger mid-dialog, rather than after the current dialog is concluded.
+- To reset a property or style to default values, you can also set a style or style property value to "default".
+- NOTE: Changing the style after some text is already printed can break existing text.
+- Colors are defined as 4 values, [red,green,blue,alpha], each ranging from 0-255.
+- Alpha is opacity; colors can be translucent by reducing Alpha below 255. 0 is fully transparent.
+
+Examples:
+- {textStyleNow "center"} immediately applies a style defined below, which centers the textbox, without overriding other existing style properties.
+- {setTextStyle "vertical"} after the current dialog ends, switches to a vertical textbox style, defined in dialogStyles.
+- {textPropertyNow "textSpeed, 25"} immediately reduces the time to print each character to 25ms.
+- {resetTextStyle} Once this text is finished, will reset the textbox to the default style.
+- {resetPropertyNow "textScale"} Immediately restores the text scale property to the default setting.
+- {textPosition "8, 8, 120"} Resizes the textbox to cover the entire screen, with 8 pixels of padding on every side.
+
+TODO: For future versions
+- Redraw existing textbox contents in new style, when switching, and then continue.
+- Recalculate textbox's center position, considering textbox margins in center calculation?
+*/
+this.hacks = this.hacks || {};
+(function (exports, bitsy) {
+'use strict';
+var hackOptions = {
+	// Determines where the textbox is positioned. "shift" moves the textbox based on the player's position.
+	verticalPosition: "shift", // options are "top", "center", "bottom", or "shift" (moves based on player position)
+	horizontalPosition: "center", // options are "left", "center", "right", or "shift" (moves based on player position)
+
+	textboxColor: [0,0,0,255], // Colors text and textbox are drawn, in [R,G,B,A]. TODO: Alpha doesn't presently work!
+	textboxWidth: 120, // Width of textbox in pixels. Default 104.
+	textboxMarginX: 4, // Pixels of space outside the left (or right) of the textbox. Default 12.
+	textboxMarginY: 4, // Pixels of space outside the top (or bottom) of the textbox. Default 12.
+
+	textColor: [255,255,255,255], // Default color of text.
+	textMinLines: 2, // Minimum number of rows for text. Determines starting textbox height. Default 2.
+	textMaxLines: 2, // Maximum number of rows for text. Determines max textbox height. Default 2.
+	textScale: 2, // Scaling factor for text. Default 2. Best with 1, 2, or 4.
+	textSpeed: 50, // Time to print each character, in milliseconds. Default 50.
+	textPaddingX: 0, // Default horizontal padding around the text.
+	textPaddingY: 2, // Default vertical padding around the text.
+
+	// Color the continue arrow is drawn using, in [R,G,B,A]
+	arrowColor: [255,255,255,255], // Foreground color of arrow sprite.
+	arrowBGColor: [0,0,0,255], // Background color. If transparent, draws no BG.
+
+	// Position of textbox continue arrow, on bottom of textbox.
+	arrowAlign: "right", // Options are: "right", "center", or "left" aligned
+
+	// Pixels of padding the arrow is inset from the edge by
+	arrowInsetX: 12,
+	arrowInsetY: 0,
+
+	// Should match dimensions of the sprite below
+	arrowWidth: 8, // Width of arrow sprite below, in pixels
+	arrowHeight: 5, // Height of arrow sprite below, in pixels
+	arrowScale: 2, // Scaling factor for arrow sprite. Default 2. Best with 1, 2, or 4.
+
+	// Pixels defining the textbox continue arrow. 1 draws a pixel in main Color, 0 draws in BG Color.
+	arrowSprite: [
+		1,1,1,1,1,1,1,1,
+		0,1,1,1,1,1,1,0,
+		0,0,1,1,1,1,0,0,
+		0,0,0,1,1,0,0,0,
+		0,0,0,0,0,0,0,0
+	],
+	// Colors the borders are drawn using, in [R,G,B,A].
+	borderColor: [128,128,128,255], // Foreground color for border tiles.
+	borderMidColor: [51,51,51,255], // Foreground color used for middle border tiles.
+	borderBGColor: [0,0,0,255], // Background color the border tiles. If transparent, draws no BG.
+	
+	// Border is drawn past the edges of the textbox.
+	// Should match dimensions of the sprite below
+	borderWidth: 8, // Width of border sprites, in pixels. Default 8.
+	borderHeight: 8, // Height of border sprites, in pixels. Default 8.
+	borderScale: 2, // Scaling factor for border sprites. Default 2. Best with 1, 2, or 4.
+	
+	// Pixels defining the corners and edges the border is drawn with. 1 draws a pixel in foreground color, 0 in BG.
+	borderUL: [
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+		0,0,1,1,1,1,1,1,
+		0,0,1,1,1,1,1,1,
+		0,0,1,1,0,0,0,0,
+		0,0,1,1,0,0,0,0,
+		0,0,1,1,0,0,0,0,
+		0,0,1,1,0,0,0,0,
+	],
+	borderU: [
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+		1,1,1,1,1,1,1,1,
+		1,1,1,1,1,1,1,1,
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+	],
+	borderUR: [
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+		1,1,1,1,1,1,0,0,
+		1,1,1,1,1,1,0,0,
+		0,0,0,0,1,1,0,0,
+		0,0,0,0,1,1,0,0,
+		0,0,0,0,1,1,0,0,
+		0,0,0,0,1,1,0,0,
+	],
+	borderL: [
+		0,0,1,1,0,0,0,0,
+		0,0,1,1,0,0,0,0,
+		0,0,1,1,0,0,0,0,
+		0,0,1,1,0,0,0,0,
+		0,0,1,1,0,0,0,0,
+		0,0,1,1,0,0,0,0,
+		0,0,1,1,0,0,0,0,
+		0,0,1,1,0,0,0,0,
+	],
+	borderR: [
+		0,0,0,0,1,1,0,0,
+		0,0,0,0,1,1,0,0,
+		0,0,0,0,1,1,0,0,
+		0,0,0,0,1,1,0,0,
+		0,0,0,0,1,1,0,0,
+		0,0,0,0,1,1,0,0,
+		0,0,0,0,1,1,0,0,
+		0,0,0,0,1,1,0,0,
+	],
+	borderDL: [
+		0,0,1,1,0,0,0,0,
+		0,0,1,1,0,0,0,0,
+		0,0,1,1,0,0,0,0,
+		0,0,1,1,0,0,0,0,
+		0,0,1,1,1,1,1,1,
+		0,0,1,1,1,1,1,1,
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+	],
+	borderD: [
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+		1,1,1,1,1,1,1,1,
+		1,1,1,1,1,1,1,1,
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+	],
+	borderDR: [
+		0,0,0,0,1,1,0,0,
+		0,0,0,0,1,1,0,0,
+		0,0,0,0,1,1,0,0,
+		0,0,0,0,1,1,0,0,
+		1,1,1,1,1,1,0,0,
+		1,1,1,1,1,1,0,0,
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+	],
+	borderM: [
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+	],
+
+	dialogStyles: {
+	// You can define alternate Dialog Styles here, which can be switched to in-game from dialog.
+	// These can be switched between using the (Style "styleName") or (ApplyStyle "styleName") commands.
+	// These Dialog Styles are meant as examples. Feel free to edit, rename, or remove them.
+		custom: {
+		// Copy any hackOptions from above into this section, and modify them, to create a new Style.
+			
+		},
+		vanilla: {
+		// An example style, which emulates the original Bitsy textbox.
+			verticalPosition: "shift",
+			horizontalPosition: "center",
+			textboxWidth: 104,
+			textboxMarginX: 12,
+			textboxMarginY: 12,
+			textMinLines: 2,
+			textMaxLines: 2,
+			textPaddingX: 8,
+			textPaddingY: 10,
+			borderWidth: 0,
+			borderHeight: 0,
+			arrowScale: 4,
+			arrowInsetX: 4,
+			arrowInsetY: 1,
+			arrowWidth: 5,
+			arrowHeight: 3,
+			arrowSprite: [
+				1,1,1,1,1,
+				0,1,1,1,0,
+				0,0,1,0,0,
+			],
+		},
+		centered: {
+		// An example style, that centers the textbox as with Starting or Ending text.
+			verticalPosition: "center",
+			horizontalPosition: "center",
+		},
+		vertical: {
+		// An example style, that positions the textbox vertically, on the left or right side.
+			verticalPosition: "center",
+			horizontalPosition: "shift",
+			textboxWidth: 48,
+			textMinLines: 16,
+			textMaxLines: 16,
+		},
+		corner: {
+		// An example style, which positions a resizing textbox in the corner opposite the player.
+			verticalPosition: "shift",
+			horizontalPosition: "shift",
+			textboxWidth: 64,
+			textMinLines: 1,
+			textMaxLines: 8,
+		},
+		inverted: {
+		// An example style, which inverts the normal textbox colors
+			textboxColor: [255,255,255,255],
+			textColor: [0,0,0,255],
+			borderColor: [128,128,128,255],
+			borderMidColor: [204,204,204,255],
+			borderBGColor: [255,255,255,255],
+			arrowColor: [0,0,0,255],
+			arrowBGColor: [255,255,255,255],
+		},
+		smallBorder: {
+		// An example style, which uses a smaller border with a blue background.
+			borderWidth: 4,
+			borderHeight: 4,
+			textPaddingX: 4,
+			textPaddingY: 4,
+			borderColor: [255,255,255,255],
+			borderBGColor: [51,153,204,255],
+			arrowBGColor: [51,153,204,255],
+			borderUL: [
+				0,0,0,0,
+				0,1,1,1,
+				0,1,1,0,
+				0,1,0,1,
+			],
+			borderU: [
+				0,0,0,0,
+				1,1,1,1,
+				0,0,0,0,
+				0,0,0,0,
+			],
+			borderUR: [
+				0,0,0,0,
+				1,1,1,0,
+				0,0,1,0,
+				0,1,1,0,
+			],
+			borderL: [
+				0,1,0,0,
+				0,1,0,0,
+				0,1,0,0,
+				0,1,0,0,
+			],
+			borderR: [
+				1,1,1,0,
+				1,1,1,0,
+				1,1,1,0,
+				1,1,1,0,
+			],
+			borderDL: [
+				0,1,0,0,
+				0,1,0,1,
+				0,1,1,1,
+				0,0,0,0,
+			],
+			borderD: [
+				1,1,1,1,
+				1,1,1,1,
+				1,1,1,1,
+				0,0,0,0,
+			],
+			borderDR: [
+				0,1,1,0,
+				1,0,1,0,
+				1,1,1,0,
+				0,0,0,0,
+			],
+			borderM: [
+				0,0,0,0,
+				0,0,0,0,
+				0,0,0,0,
+				0,0,0,0,
+			],
+		},
+	},
+};
+
+bitsy = bitsy && bitsy.hasOwnProperty('default') ? bitsy['default'] : bitsy;
+
+/**
+@file utils
+@summary miscellaneous bitsy utilities
+@author Sean S. LeBlanc
+*/
+
+/*
+Helper used to replace code in a script tag based on a search regex
+To inject code without erasing original string, using capturing groups; e.g.
+	inject(/(some string)/,'injected before $1 injected after')
+*/
+function inject(searchRegex, replaceString) {
+	// find the relevant script tag
+	var scriptTags = document.getElementsByTagName('script');
+	var scriptTag;
+	var code;
+	for (var i = 0; i < scriptTags.length; ++i) {
+		scriptTag = scriptTags[i];
+		var matchesSearch = scriptTag.textContent.search(searchRegex) !== -1;
+		var isCurrentScript = scriptTag === document.currentScript;
+		if (matchesSearch && !isCurrentScript) {
+			code = scriptTag.textContent;
+			break;
+		}
+	}
+
+	// error-handling
+	if (!code) {
+		throw 'Couldn\'t find "' + searchRegex + '" in script tags';
+	}
+
+	// modify the content
+	code = code.replace(searchRegex, replaceString);
+
+	// replace the old script tag with a new one using our modified code
+	var newScriptTag = document.createElement('script');
+	newScriptTag.textContent = code;
+	scriptTag.insertAdjacentElement('afterend', newScriptTag);
+	scriptTag.remove();
+}
+
+/**
+ * Helper for getting an array with unique elements 
+ * @param  {Array} array Original array
+ * @return {Array}       Copy of array, excluding duplicates
+ */
+function unique(array) {
+	return array.filter(function (item, idx) {
+		return array.indexOf(item) === idx;
+	});
+}
+
+/**
+
+@file kitsy-script-toolkit
+@summary makes it easier and cleaner to run code before and after Bitsy functions or to inject new code into Bitsy script tags
+@license WTFPL (do WTF you want)
+@version 4.0.1
+@requires Bitsy Version: 4.5, 4.6
+@author @mildmojo
+
+@description
+HOW TO USE:
+  import {before, after, inject, addDialogTag, addDeferredDialogTag} from "./helpers/kitsy-script-toolkit";
+
+  before(targetFuncName, beforeFn);
+  after(targetFuncName, afterFn);
+  inject(searchRegex, replaceString);
+  addDialogTag(tagName, dialogFn);
+  addDeferredDialogTag(tagName, dialogFn);
+
+  For more info, see the documentation at:
+  https://github.com/seleb/bitsy-hacks/wiki/Coding-with-kitsy
+*/
+
+
+// Ex: inject(/(names.sprite.set\( name, id \);)/, '$1console.dir(names)');
+function inject$1(searchRegex, replaceString) {
+	var kitsy = kitsyInit();
+	kitsy.queuedInjectScripts.push({
+		searchRegex: searchRegex,
+		replaceString: replaceString
+	});
+}
+
+// Ex: before('load_game', function run() { alert('Loading!'); });
+//     before('show_text', function run(text) { return text.toUpperCase(); });
+//     before('show_text', function run(text, done) { done(text.toUpperCase()); });
+function before(targetFuncName, beforeFn) {
+	var kitsy = kitsyInit();
+	kitsy.queuedBeforeScripts[targetFuncName] = kitsy.queuedBeforeScripts[targetFuncName] || [];
+	kitsy.queuedBeforeScripts[targetFuncName].push(beforeFn);
+}
+
+// Ex: after('load_game', function run() { alert('Loaded!'); });
+function after(targetFuncName, afterFn) {
+	var kitsy = kitsyInit();
+	kitsy.queuedAfterScripts[targetFuncName] = kitsy.queuedAfterScripts[targetFuncName] || [];
+	kitsy.queuedAfterScripts[targetFuncName].push(afterFn);
+}
+
+function kitsyInit() {
+	// return already-initialized kitsy
+	if (bitsy.kitsy) {
+		return bitsy.kitsy;
+	}
+
+	// Initialize kitsy
+	bitsy.kitsy = {
+		queuedInjectScripts: [],
+		queuedBeforeScripts: {},
+		queuedAfterScripts: {}
+	};
+
+	var oldStartFunc = bitsy.startExportedGame;
+	bitsy.startExportedGame = function doAllInjections() {
+		// Only do this once.
+		bitsy.startExportedGame = oldStartFunc;
+
+		// Rewrite scripts and hook everything up.
+		doInjects();
+		applyAllHooks();
+
+		// Start the game
+		bitsy.startExportedGame.apply(this, arguments);
+	};
+
+	return bitsy.kitsy;
+}
+
+
+function doInjects() {
+	bitsy.kitsy.queuedInjectScripts.forEach(function (injectScript) {
+		inject(injectScript.searchRegex, injectScript.replaceString);
+	});
+	_reinitEngine();
+}
+
+function applyAllHooks() {
+	var allHooks = unique(Object.keys(bitsy.kitsy.queuedBeforeScripts).concat(Object.keys(bitsy.kitsy.queuedAfterScripts)));
+	allHooks.forEach(applyHook);
+}
+
+function applyHook(functionName) {
+	var functionNameSegments = functionName.split('.');
+	var obj = bitsy;
+	while (functionNameSegments.length > 1) {
+		obj = obj[functionNameSegments.shift()];
+	}
+	var lastSegment = functionNameSegments[0];
+	var superFn = obj[lastSegment];
+	var superFnLength = superFn ? superFn.length : 0;
+	var functions = [];
+	// start with befores
+	functions = functions.concat(bitsy.kitsy.queuedBeforeScripts[functionName] || []);
+	// then original
+	if (superFn) {
+		functions.push(superFn);
+	}
+	// then afters
+	functions = functions.concat(bitsy.kitsy.queuedAfterScripts[functionName] || []);
+
+	// overwrite original with one which will call each in order
+	obj[lastSegment] = function () {
+		var returnVal;
+		var args = [].slice.call(arguments);
+		var i = 0;
+
+		function runBefore() {
+			// All outta functions? Finish
+			if (i === functions.length) {
+				return returnVal;
+			}
+
+			// Update args if provided.
+			if (arguments.length > 0) {
+				args = [].slice.call(arguments);
+			}
+
+			if (functions[i].length > superFnLength) {
+				// Assume funcs that accept more args than the original are
+				// async and accept a callback as an additional argument.
+				return functions[i++].apply(this, args.concat(runBefore.bind(this)));
+			} else {
+				// run synchronously
+				returnVal = functions[i++].apply(this, args);
+				if (returnVal && returnVal.length) {
+					args = returnVal;
+				}
+				return runBefore.apply(this, args);
+			}
+		}
+
+		return runBefore.apply(this, arguments);
+	};
+}
+
+function _reinitEngine() {
+	// recreate the script and dialog objects so that they'll be
+	// referencing the code with injections instead of the original
+	bitsy.scriptModule = new bitsy.Script();
+	bitsy.scriptInterpreter = bitsy.scriptModule.CreateInterpreter();
+
+	bitsy.dialogModule = new bitsy.Dialog();
+	bitsy.dialogRenderer = bitsy.dialogModule.CreateRenderer();
+	bitsy.dialogBuffer = bitsy.dialogModule.CreateBuffer();
+}
+
+// Rewrite custom functions' parentheses to curly braces for Bitsy's
+// interpreter. Unescape escaped parentheticals, too.
+function convertDialogTags(input, tag) {
+	return input
+		.replace(new RegExp('\\\\?\\((' + tag + '(\\s+(".+?"|.+?))?)\\\\?\\)', 'g'), function (match, group) {
+			if (match.substr(0, 1) === '\\') {
+				return '(' + group + ')'; // Rewrite \(tag "..."|...\) to (tag "..."|...)
+			}
+			return '{' + group + '}'; // Rewrite (tag "..."|...) to {tag "..."|...}
+		});
+}
+
+
+function addDialogFunction(tag, fn) {
+	var kitsy = kitsyInit();
+	kitsy.dialogFunctions = kitsy.dialogFunctions || {};
+	if (kitsy.dialogFunctions[tag]) {
+		throw new Error('The dialog function "' + tag + '" already exists.');
+	}
+
+	// Hook into game load and rewrite custom functions in game data to Bitsy format.
+	before('parseWorld', function (game_data) {
+		return [convertDialogTags(game_data, tag)];
+	});
+
+	kitsy.dialogFunctions[tag] = fn;
+}
+
+/**
+ * Adds a custom dialog tag which executes the provided function.
+ * For ease-of-use with the bitsy editor, tags can be written as
+ * (tagname "parameters") in addition to the standard {tagname "parameters"}
+ * 
+ * Function is executed immediately when the tag is reached.
+ *
+ * @param {string}   tag Name of tag
+ * @param {Function} fn  Function to execute, with signature `function(environment, parameters, onReturn){}`
+ *                       environment: provides access to SetVariable/GetVariable (among other things, see Environment in the bitsy source for more info)
+ *                       parameters: array containing parameters as string in first element (i.e. `parameters[0]`)
+ *                       onReturn: function to call with return value (just call `onReturn(null);` at the end of your function if your tag doesn't interact with the logic system)
+ */
+function addDialogTag(tag, fn) {
+	addDialogFunction(tag, fn);
+	inject$1(
+		/(var functionMap = new Map\(\);)/,
+		'$1functionMap.set("' + tag + '", kitsy.dialogFunctions.' + tag + ');'
+	);
+}
+
+/**
+ * Adds a custom dialog tag which executes the provided function.
+ * For ease-of-use with the bitsy editor, tags can be written as
+ * (tagname "parameters") in addition to the standard {tagname "parameters"}
+ * 
+ * Function is executed after the dialog box.
+ *
+ * @param {string}   tag Name of tag
+ * @param {Function} fn  Function to execute, with signature `function(environment, parameters){}`
+ *                       environment: provides access to SetVariable/GetVariable (among other things, see Environment in the bitsy source for more info)
+ *                       parameters: array containing parameters as string in first element (i.e. `parameters[0]`)
+ */
+function addDeferredDialogTag(tag, fn) {
+	addDialogFunction(tag, fn);
+	bitsy.kitsy.deferredDialogFunctions = bitsy.kitsy.deferredDialogFunctions || {};
+	var deferred = bitsy.kitsy.deferredDialogFunctions[tag] = [];
+	inject$1(
+		/(var functionMap = new Map\(\);)/,
+		'$1functionMap.set("' + tag + '", function(e, p, o){ kitsy.deferredDialogFunctions.' + tag + '.push({e:e,p:p}); o(null); });'
+	);
+	// Hook into the dialog finish event and execute the actual function
+	after('onExitDialog', function () {
+		while (deferred.length) {
+			var args = deferred.shift();
+			bitsy.kitsy.dialogFunctions[tag](args.e, args.p, args.o);
+		}
+	});
+	// Hook into the game reset and make sure data gets cleared
+	after('clearGameData', function () {
+		deferred.length = 0;
+	});
+}
+
+/**
+ * Helper for printing a paragraph break inside of a dialog function.
+ * Adds the function `AddParagraphBreak` to `DialogBuffer`
+ */
+
+inject$1(/(this\.AddLinebreak = )/, 'this.AddParagraphBreak = function() { buffer.push( [[]] ); isActive = true; };\n$1');
+
+/**
+📃
+@file paragraph-break
+@summary Adds paragraph breaks to the dialogue parser
+@license WTFPL (do WTF you want)
+@version 1.1.5
+@requires Bitsy Version: 5.0, 5.1
+@author Sean S. LeBlanc, David Mowatt
+
+@description
+Adds a (p) tag to the dialogue parser that forces the following text to
+start on a fresh dialogue screen, eliminating the need to spend hours testing
+line lengths or adding multiple line breaks that then have to be reviewed
+when you make edits or change the font size.
+
+Usage: (p)
+
+Example: I am a cat(p)and my dialogue contains multitudes
+
+HOW TO USE:
+  1. Copy-paste this script into a new script tag after the Bitsy source code.
+     It should appear *before* any other mods that handle loading your game
+     data so it executes *after* them (last-in first-out).
+
+NOTE: This uses parentheses "()" instead of curly braces "{}" around function
+      calls because the Bitsy editor's fancy dialog window strips unrecognized
+      curly-brace functions from dialog text. To keep from losing data, write
+      these function calls with parentheses like the examples above.
+
+      For full editor integration, you'd *probably* also need to paste this
+      code at the end of the editor's `bitsy.js` file. Untested.
+*/
+
+// Adds the actual dialogue tag. No deferred version is required.
+addDialogTag('p', function (environment, parameters, onReturn) {
+	environment.GetDialogBuffer().AddParagraphBreak();
+	onReturn(null);
+});
+// End of (p) paragraph break mod
+
+
+
+// Applies only a Style's defined attributes to the current textbox style.
+// {style "StyleName"}
+// {textStyleNow "StyleName"}
+addDialogTag('textStyleNow', function (environment, parameters, onReturn) {
+	textboxStyler.style(parameters[0]);
+	onReturn(null);
+});
+addDeferredDialogTag('textStyle', function (environment, parameters) {
+	textboxStyler.style(parameters[0]);
+});
+
+// Sets the current Style of the textbox (undefined attributes use Defaults instead)
+// {setTextStyle "StyleName"}
+// {setTextStyleNow "StyleName"}
+addDialogTag('setTextStyleNow', function (environment, parameters, onReturn) {
+	textboxStyler.setStyle(parameters[0]);
+	onReturn(null);
+});
+addDeferredDialogTag('setTextStyle', function (environment, parameters) {
+	textboxStyler.setStyle(parameters[0]);
+});
+
+// Applies the current Style of the textbox (undefined attributes use Defaults instead)
+// {textProperty "StyleProperty, StyleValue"}
+// {textPropertyNow "StyleProperty, StyleValue"}
+addDialogTag('textPropertyNow', function (environment, parameters, onReturn) {
+	var params = parameters[0].split(',');
+	textboxStyler.setProperty(params[0], params[1]);
+	onReturn(null);
+});
+addDeferredDialogTag('textProperty', function (environment, parameters) {
+	var params = parameters[0].split(',');
+	textboxStyler.setProperty(params[0], params[1]);
+});
+
+// Resets the Style of the textbox to the Default style.
+// {resetTextStyle}
+// {resetTextStyleNow}
+addDialogTag('resetTextStyleNow', function (environment, parameters, onReturn) {
+	textboxStyler.resetStyle();
+	onReturn(null);
+});
+addDeferredDialogTag('resetTextStyle', function (environment, parameters) {
+	textboxStyler.resetStyle();
+});
+
+// Resets a Style Property of the textbox to it's Default value.
+// {resetTextProperty "StyleProperty"}
+// {resetTextPropertyNow "StyleProperty"}
+addDialogTag('resetTextPropertyNow', function (environment, parameters, onReturn) {
+	textboxStyler.resetProperty(parameters[0]);
+	onReturn(null);
+});
+addDeferredDialogTag('resetTextProperty', function (environment, parameters) {
+	textboxStyler.resetProperty(parameters[0]);
+});
+
+// Repositions and resizes textbox at an absolute position, based on coordinates.
+// {textPosition "x, y, width, minLines, maxLines"}
+// {textPositionNow "x, y, width, minLines, maxLines"}
+addDialogTag('textPositionNow', function (environment, parameters, onReturn) {
+	var params = parameters[0].split(',');
+	textboxStyler.textboxPosition(params[0],params[1],params[2],params[3],params[4]);
+	onReturn(null);
+});
+addDeferredDialogTag('textPosition', function (environment, parameters) {
+	var params = parameters[0].split(',');
+	textboxStyler.textboxPosition(params[0],params[1],params[2],params[3],params[4]);
+});
+
+
+
+// =============================================================
+// | HACK SCRIPT INJECTS |/////////////////////////////////////|
+// =============================================================
+// Replaces initial textbox parameters, based on currently active style (or defaults).
+// Makes textboxInfo available at the window level
+// Recalculates textbox parameters, even values no longer used with hack, for compatability.
+var textboxInfoReplace = `var textboxInfo = {
+	img : null,
+	width : textboxStyler.activeStyle.textboxWidth,
+	height : textboxStyler.activeStyle.textPaddingY + textboxStyler.activeStyle.borderHeight - 2 + (2 * textboxStyler.activeStyle.textMinLines),
+	top : textboxStyler.activeStyle.textboxMarginY,
+	left : textboxStyler.activeStyle.textboxMarginX,
+	bottom : textboxStyler.activeStyle.textboxMarginY,
+	font_scale : textboxStyler.activeStyle.textScale/4,
+	padding_vert : textboxStyler.activeStyle.textPaddingY,
+	padding_horz : textboxStyler.activeStyle.textPaddingX,
+	arrow_height : textboxStyler.activeStyle.textPaddingY + textboxStyler.activeStyle.borderHeight - 4,
+};
+window.textboxInfo = textboxInfo;`;
+inject$1(/var textboxInfo = [^]*?};/, textboxInfoReplace);
+
+// Replaces ClearTextbox function to include border-drawing scripts
+var clearTextboxReplace = `this.ClearTextbox = function() {
+	if(context == null) return;
+
+	//create new image none exists
+	if(textboxInfo.img == null)
+		textboxInfo.img = context.createImageData(textboxInfo.width*scale, textboxInfo.height*scale);
+
+	// Draw Textbox Background based on BGColor (indices are R,G,B, and A)
+	for (var i=0;i<textboxInfo.img.data.length;i+=4)
+	{
+		textboxInfo.img.data[i+0]=textboxStyler.activeStyle.textboxColor[0];
+		textboxInfo.img.data[i+1]=textboxStyler.activeStyle.textboxColor[1];
+		textboxInfo.img.data[i+2]=textboxStyler.activeStyle.textboxColor[2];
+		textboxInfo.img.data[i+3]=textboxStyler.activeStyle.textboxColor[3];
+	}
+
+	textboxStyler.drawBorder();
+};`;
+inject$1(/this.ClearTextbox = [^]*?};/, clearTextboxReplace);
+
+// Replaces Draw Textbox function, with function that supports vertical and horizontal shifting
+var drawTextboxReplace = `this.DrawTextbox = function() {
+	if(context == null) return;
+
+	// Textbox defaults to center-aligned
+	var textboxXPosition = ((width/2)-(textboxInfo.width/2))*scale;
+	var textboxYPosition = ((height/2)-(textboxInfo.height/2))*scale;
+
+	if (isCentered) {
+		context.putImageData(textboxInfo.img, textboxXPosition, textboxYPosition);
+	}
+	else {
+		if (textboxStyler.activeStyle.verticalPosition.toLowerCase() == "shift") {
+			if (player().y < mapsize/2) {
+				//player on bottom half, so draw on top
+				textboxYPosition = ((height-textboxInfo.top-textboxInfo.height)*scale);
+			}
+			else {
+				textboxYPosition = textboxInfo.top*scale;
+			}
+		}
+		else if (textboxStyler.activeStyle.verticalPosition.toLowerCase() == "top") {
+			textboxYPosition = textboxInfo.top*scale;
+		}
+		else if (textboxStyler.activeStyle.verticalPosition.toLowerCase() == "bottom") {
+			textboxYPosition = ((height-textboxInfo.top-textboxInfo.height)*scale);
+		}
+
+		if (textboxStyler.activeStyle.horizontalPosition.toLowerCase() == "shift") {
+			if (player().x < mapsize/2) {
+				// player on left half, so draw on right
+				textboxXPosition = ((width-textboxInfo.left-textboxInfo.width)*scale);
+			}
+			else {
+				textboxXPosition = textboxInfo.left*scale;
+			}
+		}
+		else if (textboxStyler.activeStyle.horizontalPosition.toLowerCase() == "right") {
+			textboxXPosition = ((width-textboxInfo.left-textboxInfo.width)*scale);
+		}
+		else if (textboxStyler.activeStyle.horizontalPosition.toLowerCase() == "left") {
+			textboxXPosition = textboxInfo.left*scale;
+		}
+
+		// Draw the Textbox
+		context.putImageData(textboxInfo.img, textboxXPosition, textboxYPosition);
+	}
+};`;
+inject$1(/this.DrawTextbox = [^]*?};/, drawTextboxReplace);
+
+// Replace DrawNextArrow function, to support custom sprites, colors, and arrow repositioning
+var drawNextArrowReplace = `this.DrawNextArrow = function() {
+	// Arrow sprite is center-bottom by default
+	var top = ((4/textboxStyler.activeStyle.arrowScale)*textboxInfo.height - textboxStyler.activeStyle.arrowHeight - textboxStyler.activeStyle.arrowInsetY) *  textboxStyler.activeStyle.arrowScale;
+	var left = ((4/textboxStyler.activeStyle.textboxArrowScale)*textboxInfo.width - textboxStyler.activeStyle.arrowXSize) * textboxStyler.activeStyle.textboxArrowScale*0.5;
+
+	// Reposition arrow based on arrowAlign and RTL settings (flipped for RTL Languages)
+	if (textboxStyler.activeStyle.arrowAlign.toLowerCase() == "left") {
+		if (textDirection === TextDirection.RightToLeft) {
+			left = ((4/textboxStyler.activeStyle.arrowScale)*textboxInfo.width - textboxStyler.activeStyle.arrowWidth - textboxStyler.activeStyle.arrowInsetX) *  textboxStyler.activeStyle.arrowScale;
+		}
+		else {
+			left = (textboxStyler.activeStyle.arrowXPadding) * textboxStyler.activeStyle.textboxArrowScale;
+		}
+	}
+	else if (textboxStyler.activeStyle.arrowAlign.toLowerCase() == "right") {
+		if (textDirection === TextDirection.RightToLeft) {
+			left = (arrowXPadding) * textboxArrowScale;
+		}
+		else {
+			left = ((4/textboxStyler.activeStyle.arrowScale)*textboxInfo.width - textboxStyler.activeStyle.arrowWidth - textboxStyler.activeStyle.arrowInsetX) *  textboxStyler.activeStyle.arrowScale;
+		}
+	}
+	
+	// Draw arrow sprite pixels on textbox
+	for (var y = 0; y < textboxStyler.activeStyle.arrowHeight; y++) {
+		for (var x = 0; x < textboxStyler.activeStyle.arrowWidth; x++) {
+			var i = (y * textboxStyler.activeStyle.arrowWidth) + x;
+
+			//scaling hooplah
+			for (var sy = 0; sy < textboxStyler.activeStyle.arrowScale; sy++) {
+				for (var sx = 0; sx < textboxStyler.activeStyle.arrowScale; sx++) {
+					var pxl = 4 * ( ((top+(y*textboxStyler.activeStyle.arrowScale)+sy) * (textboxInfo.width*4)) + (left+(x*textboxStyler.activeStyle.arrowScale)+sx) );
+					// Draws arrow's pixels in Arrow Color
+					if (textboxStyler.activeStyle.arrowSprite[i] == 1) {
+						textboxInfo.img.data[pxl+0] = textboxStyler.activeStyle.arrowColor[0];
+						textboxInfo.img.data[pxl+1] = textboxStyler.activeStyle.arrowColor[1];
+						textboxInfo.img.data[pxl+2] = textboxStyler.activeStyle.arrowColor[2];
+						textboxInfo.img.data[pxl+3] = textboxStyler.activeStyle.arrowColor[3];
+					}
+					// Draws arrow's bg pixels using Arrow BG Color
+					else {
+						textboxInfo.img.data[pxl+0] = textboxStyler.activeStyle.arrowBGColor[0];
+						textboxInfo.img.data[pxl+1] = textboxStyler.activeStyle.arrowBGColor[1];
+						textboxInfo.img.data[pxl+2] = textboxStyler.activeStyle.arrowBGColor[2];
+						textboxInfo.img.data[pxl+3] = textboxStyler.activeStyle.arrowBGColor[3];
+					}
+				}
+			}
+		}
+	}
+};`;
+inject$1(/this.DrawNextArrow = [^]*?};/, drawNextArrowReplace);
+
+// Inject to support custom text scaling
+inject$1(/var text_scale = .+?;/, 'var text_scale = textboxStyler.activeStyle.textScale;');
+
+// Injects to support text padding within the textbox
+var topTextPaddingReplace = `var top = (2 * textboxStyler.activeStyle.textPaddingY) + (textboxStyler.activeStyle.borderHeight * 2) + (row * 2 * scale) + (row * font.getHeight() * textboxStyler.activeStyle.textScale) + Math.floor( char.offset.y );`;
+var leftTextPaddingReplace = `var left = (2* textboxStyler.activeStyle.textPaddingX) + (textboxStyler.activeStyle.borderWidth * 2) + (leftPos * textboxStyler.activeStyle.textScale) + Math.floor( char.offset.x );`;
+inject$1(/var top = \(4 \* scale\) \+ \(row \* 2 \* scale\) .+?\);/, topTextPaddingReplace);
+inject$1(/var left = \(4 \* scale\) \+ \(leftPos \* text_scale\) .+?\);/, leftTextPaddingReplace);
+
+// Inject to support custom text speeds
+inject$1(/var nextCharMaxTime = .+?;/, 'var nextCharMaxTime = textboxStyler.activeStyle.textSpeed;');
+
+// Inject to support custom default text color
+inject$1(/this.color = .+?};/, 'this.color = { r:textboxStyler.activeStyle.textColor[0], g:textboxStyler.activeStyle.textColor[1], b:textboxStyler.activeStyle.textColor[2], a:textboxStyler.activeStyle.textColor[3] };');
+
+// Inject to support dynamic textbox resizing. Attach to window to make it accessible from hack.
+inject$1(/var pixelsPerRow = .+?;/, 'window.pixelsPerRow = (textboxStyler.activeStyle.textboxWidth*(4/textboxStyler.activeStyle.textScale)) - (textboxStyler.activeStyle.borderWidth*(4/textboxStyler.activeStyle.textScale)) - (textboxStyler.activeStyle.textPaddingX*(4/textboxStyler.activeStyle.textScale));');
+//var pixelsPerRow = (textboxWidth*2) - (borderWidth*2) - (textPaddingX*2); // hard-coded fun times!!! 192
+
+// Store font height at parent level when calculated.
+var fontSizeInject = `else if (args[0] == "SIZE") {
+	width = parseInt(args[1]);
+	height = parseInt(args[2]);
+	window.fontHeight = height;
+	console.log(fontHeight);
+}`;
+inject$1(/else if \(args\[0\] == "SIZE"\) {[^]*?}/, fontSizeInject);
+console.log(fontSizeInject);
+// =============================================================
+// | RE-IMPLIMENTED LONG DIALOG HACK INJECTS |/////////////////|
+// =============================================================
+// Modified from Sean leBlanc's Long Dialog hack, to include textbox borders and padding
+// Needed to recalculate textbox height, based on current style parameters.
+// Added textMinLines and textMaxLines to hackOptions parameters, to include in style swapping
+
+// override textbox height (and recalculate textboxWidth)
+inject$1(/textboxInfo\.height = .+;/, `Object.defineProperty(textboxInfo, 'height', {
+	get() { return textboxStyler.activeStyle.textPaddingY + textboxStyler.activeStyle.borderHeight - 2 + ((2 + relativeFontHeight()) * Math.max(textboxStyler.activeStyle.textMinLines, dialogBuffer.CurPage().indexOf(dialogBuffer.CurRow())+Math.sign(dialogBuffer.CurCharCount()))); }
+})`);
+
+// prevent textbox from caching
+inject$1(/(if\(textboxInfo\.img == null\))/, '// $1');
+
+// rewrite hard-coded row limit
+inject$1(/(else if \(curRowIndex )== 0/g, '$1 < textboxStyler.activeStyle.textMaxLines - 1');
+inject$1(/(if\( lastPage\.length) <= 1( \) {)/, '$1 < textboxStyler.activeStyle.textMaxLines $2');
+
+// =============================================================
+// | HACK FUNCTIONS |//////////////////////////////////////////|
+// =============================================================
+
+// Make them accessible at a higher scope, so Dialog functions can see them.
+window.textboxStyler = {
+	defaultStyle: {
+		verticalPosition: hackOptions.verticalPosition,
+		horizontalPosition: hackOptions.horizontalPosition,
+		textboxColor: hackOptions.textboxColor,
+		textboxWidth: hackOptions.textboxWidth,
+		textboxMarginX: hackOptions.textboxMarginX,
+		textboxMarginY: hackOptions.textboxMarginY,
+		textColor: hackOptions.textColor,
+		textMinLines: hackOptions.textMinLines,
+		textMaxLines: hackOptions.textMaxLines,
+		textScale: hackOptions.textScale,
+		textSpeed: hackOptions.textSpeed,
+		textPaddingX: hackOptions.textPaddingX,
+		textPaddingY: hackOptions.textPaddingY,
+		borderColor: hackOptions.borderColor,
+		borderBGColor: hackOptions.borderBGColor,
+		borderMidColor: hackOptions.borderMidColor,
+		borderWidth: hackOptions.borderWidth,
+		borderHeight: hackOptions.borderHeight,
+		borderScale: hackOptions.borderScale,
+		arrowColor: hackOptions.arrowColor,
+		arrowBGColor: hackOptions.arrowBGColor,
+		arrowScale: hackOptions.arrowScale,
+		arrowAlign: hackOptions.arrowAlign,
+		arrowInsetX: hackOptions.arrowInsetX,
+		arrowInsetY: hackOptions.arrowInsetY,
+		arrowWidth: hackOptions.arrowWidth,
+		arrowHeight: hackOptions.arrowHeight,
+		arrowSprite: hackOptions.arrowSprite,
+		borderUL: hackOptions.borderUL,
+		borderU: hackOptions.borderU,
+		borderUR: hackOptions.borderUR,
+		borderL: hackOptions.borderL,
+		borderR: hackOptions.borderR,
+		borderDL: hackOptions.borderDL,
+		borderD: hackOptions.borderD,
+		borderDR: hackOptions.borderDR,
+		borderM: hackOptions.borderM,
+	},
+
+	activeStyle: {
+		verticalPosition: hackOptions.verticalPosition,
+		horizontalPosition: hackOptions.horizontalPosition,
+		textboxColor: hackOptions.textboxColor,
+		textboxWidth: hackOptions.textboxWidth,
+		textboxMarginX: hackOptions.textboxMarginX,
+		textboxMarginY: hackOptions.textboxMarginY,
+		textColor: hackOptions.textColor,
+		textMinLines: hackOptions.textMinLines,
+		textMaxLines: hackOptions.textMaxLines,
+		textScale: hackOptions.textScale,
+		textSpeed: hackOptions.textSpeed,
+		textPaddingX: hackOptions.textPaddingX,
+		textPaddingY: hackOptions.textPaddingY,
+		borderColor: hackOptions.borderColor,
+		borderBGColor: hackOptions.borderBGColor,
+		borderMidColor: hackOptions.borderMidColor,
+		borderWidth: hackOptions.borderWidth,
+		borderHeight: hackOptions.borderHeight,
+		borderScale: hackOptions.borderScale,
+		arrowColor: hackOptions.arrowColor,
+		arrowBGColor: hackOptions.arrowBGColor,
+		arrowScale: hackOptions.arrowScale,
+		arrowAlign: hackOptions.arrowAlign,
+		arrowInsetX: hackOptions.arrowInsetX,
+		arrowInsetY: hackOptions.arrowInsetY,
+		arrowWidth: hackOptions.arrowWidth,
+		arrowHeight: hackOptions.arrowHeight,
+		arrowSprite: hackOptions.arrowSprite,
+		borderUL: hackOptions.borderUL,
+		borderU: hackOptions.borderU,
+		borderUR: hackOptions.borderUR,
+		borderL: hackOptions.borderL,
+		borderR: hackOptions.borderR,
+		borderDL: hackOptions.borderDL,
+		borderD: hackOptions.borderD,
+		borderDR: hackOptions.borderDR,
+		borderM: hackOptions.borderM,
+	},
+
+	styles: hackOptions.dialogStyles,
+
+	// Sets activeStyle elements to the new style if defined, or to defaultStyle's elements if not.
+	style: function (newStyle) {
+		console.log ("SETTING TEXTBOX STYLE TO: " + newStyle);
+		// If newStyle doesn't exist, resets to default
+		if (newStyle == undefined || textboxStyler.styles[newStyle] == undefined) {
+			textboxStyler.resetStyle();
+			console.log ("UNDEFINED STYLE. RESETTING TO DEFAULT.");
+			return false;
+		}
+		textboxStyler.activeStyle = Object.assign({}, textboxStyler.defaultStyle, textboxStyler.styles[newStyle]);
+		/*
+		Object.keys(textboxStyler.activeStyle).forEach(function(prop) {
+			if (textboxStyler.styles[newStyle].hasOwnProperty(prop)) {
+				textboxStyler.activeStyle[prop] = textboxStyler.styles[newStyle][prop];
+			}
+			else {
+				textboxStyler.activeStyle[prop] = textboxStyler.defaultStyle[prop];
+			}
+		});
+		*/
+		textboxStyler.updateTextbox(); // Updates values used for rendering text.
+	},
+	// Applies defined style parameters to the existing style, without changing anything else.
+	setStyle: function (newStyle) {
+		console.log ("APPLYING STYLE " + newStyle + " TO EXISTING TEXTBOX STYLE");
+		// If newStyle doesn't exist, does nothing.
+		if (textboxStyler.styles[newStyle] == undefined) {
+			console.log ("UNDEFINED STYLE.");
+			return false;
+		}
+		textboxStyler.activeStyle = Object.assign({}, textboxStyler.activeStyle, textboxStyler.styles[newStyle]);
+		/*
+		Object.keys(textboxStyler.activeStyle).forEach(function(prop) {
+			if (textboxStyler.styles[newStyle].hasOwnProperty(prop))
+			{
+				textboxStyler.activeStyle[prop] = textboxStyler.styles[newStyle][prop];
+			}
+		});
+		*/
+		textboxStyler.updateTextbox();
+	},
+	// Manually sets a specific property of the active style.
+	setProperty: function (property, value) {
+		value = "default";
+		console.log ("APPLYING STYLE PROPERTY: " + property + ", " + value);
+		if (textboxStyler.activeStyle.hasOwnProperty(property)) {
+			if (value == undefined || value == "default") {
+				console.log ("UNDEFINED PROPERTY. SETTING TO DEFAULT.");
+				//textboxStyle.activeStyle[property] = textboxStyle.defaultStyle[property];
+				textboxStyler.activeStyle[property] = Object.assign({}, textboxStyler.defaultStyle)[property];
+			}
+			else {
+				textboxStyler.activeStyle[property] = value;
+			}
+		}
+
+		textboxStyler.updateTextbox();
+	},
+	// Resets Active Textbox Style to Default Style
+	resetStyle: function () {
+		console.log ("RESETTING TO DEFAULT TEXTBOX STYLE");
+		//textboxStyler.activeStyle = textboxStyler.defaultStyle;
+		textboxStyler.activeStyle = Object.assign({}, textboxStyler.defaultStyle);
+
+		textboxStyler.updateTextbox();
+	},
+	// Resets a Textbox Style Property to it's Default value
+	resetProperty: function (property) {
+		console.log ("RESETTING STYLE PROPERTY TO DEFAULT: " + property);
+		if (textboxStyler.activeStyle.hasOwnProperty(property)) {
+			// textboxStyle.activeStyle[property] = textboxStyle.defaultStyle[property]; //Don't do it like this. Clone object instead of passing ref.
+			textboxStyler.activeStyle[property] = Object.assign({}, textboxStyler.defaultStyle)[property];
+		}
+		else {
+			console.log ("UNDEFINED PROPERTY.");
+			return false;
+		}
+
+		textboxStyler.updateTextbox();
+	},
+	// A command to set or adjust the absolute position, width, and lines of a textbox.
+	textboxPosition: function (x, y, boxWidth, boxMinLines, boxMaxLines) {
+		var curX = textboxStyler.activeStyle.textboxMarginX;
+		var curY = textboxStyler.activeStyle.textboxMarginY;
+		var curWidth = textboxStyler.activeStyle.textboxWidth;
+		var curMinLines = textboxStyler.activeStyle.textboxMinLines;
+		var curMaxLines = textboxStyler.activeStyle.textboxMaxLines;
+
+		// X Position
+		if (x == undefined) {
+			x = curX;
+		}
+		else {
+			x = x.toString().trim();
+			if (x == "" ) { x = curX; }
+			else if (x.includes("+")) { x = curX + parseInt(x.substring(1)); }
+			else if (x.includes("-")) { x = curX - parseInt(x.substring(1)); }
+		}
+		if (x < -128 || x > 128) {
+			console.log("CLAMPING X POSITION. XPOS ("+x+") OUT OF BOUNDS. 0-128 EXPECTED.");
+			x = Math.max(0, Math.min(x, 128));
+		}
+		// Y Position
+		if (y == undefined) {
+			y = curY;
+		}
+		else {
+			y = y.toString().trim();
+			if (y == "" ) { y = curY; }
+			else if (y.includes("+")) { y = curY + parseInt(y.substring(1)); }
+			else if (y.includes("-")) { y = curY - parseInt(y.substring(1)); }
+		}
+		if (y < -128 || y > 128) {
+			console.log("CLAMPING Y POSITION. YPOS ("+y+") OUT OF BOUNDS. 0-128 EXPECTED.");
+			y = Math.max(0, Math.min(y, 128));
+		}
+		// Width
+		if (boxWidth == undefined) {
+			boxWidth = curWidth;
+		}
+		else {
+			boxWidth = boxWidth.toString().trim();
+			if (boxWidth == "" ) { boxWidth = curWidth; }
+			else if (boxWidth.includes("+")) { boxWidth = curWidth + parseInt(boxWidth.substring(1)); }
+			else if (boxWidth.includes("-")) { boxWidth = curWidth - parseInt(boxWidth.substring(1)); }
+		}
+		if (boxWidth < 0 || boxWidth > 128) {
+			console.log("CLAMPING WIDTH ("+(boxWidth)+"). 0-128 EXPECTED.");
+			boxWidth = Math.max(0, Math.min(boxWidth, 128));
+		}
+		// Minimum Lines
+		if (boxMinLines == undefined) {
+			boxMinLines = curMinLines;
+		}
+		else {
+			boxMinLines = boxMinLines.toString().trim();
+			if (boxMinLines == "" ) { boxMinLines = curMinLines; }
+			else if (boxMinLines.includes("+")) { boxMinLines = curMinLines + parseInt(boxMinLines.substring(1)); }
+			else if (boxMinLines.includes("-")) { boxMinLines = curMinLines - parseInt(boxMinLines.substring(1)); }
+		}
+		if (boxMinLines < 0 || boxMinLines > 128) {
+			console.log("CLAMPING TEXT MIN LINES ("+(boxMinLines)+"). 0-128 EXPECTED.");
+			boxMinLines = Math.max(0, Math.min(boxMinLines, 128));
+		}
+		// Maximum Lines
+		if (boxMaxLines == undefined) {
+			boxMaxLines = curMaxLines;
+		}
+		else {
+			boxMaxLines = boxMaxLines.toString().trim();
+			if (boxMaxLines == "" ) { boxMaxLines = boxMaxLines; }
+			else if (boxMaxLines.includes("+")) { boxMaxLines = boxMaxLines + parseInt(boxMaxLines.substring(1)); }
+			else if (boxMaxLines.includes("-")) { boxMaxLines = boxMaxLines - parseInt(boxMaxLines.substring(1)); }
+		}
+		if (boxMaxLines < 0 || boxMaxLines > 128) {
+			console.log("CLAMPING TEXT MAX LINES ("+(boxMaxLines)+"). 0-128 EXPECTED.");
+			boxMaxLines = Math.max(0, Math.min(boxMaxLines, 128));
+		}
+
+		textboxStyler.activeStyle.textboxWidth = boxWidth;
+		textboxStyler.activeStyle.textboxMinLines = boxMinLines;
+		textboxStyler.activeStyle.textboxMaxLines = boxMaxLines;
+		textboxStyler.activeStyle.textboxMarginY = y;
+		textboxStyler.activeStyle.textboxMarginX = x;
+		textboxStyler.activeStyle.verticalPosition = "top";
+		textboxStyler.activeStyle.horizontalPosition = "left";
+
+		textboxStyler.updateTextbox();
+	},
+
+	// First draft of position. Kept here for future versions.
+	textboxCornersWIP: function (x1, y1, x2, y2) {
+		// Trim and sanitize X and Y Positions, and set to current position if omitted.
+		var curX1 = textboxStyler.activeStyle.textboxMarginX;
+		var curX2 = curX1 + textboxStyler.activeStyle.textboxWidth;
+		var curY1 = textboxStyler.activeStyle.textboxMarginY;
+		var curY2 = curY1 + (textboxStyler.activeStyle.textPaddingY + textboxStyler.activeStyle.borderHeight - 2 + (2 * textboxStyler.activeStyle.textMinLines));
+
+		if (x1 == undefined) {
+			x1 = curX1;
+		}
+		else {
+			x1 = x1.toString().trim();
+			if (x1 == "" ) { x1 = curX1; }
+			else if (x1.includes("+")) { x1 = curX1 + parseInt(x1.substring(1)); }
+			else if (x1.includes("-")) { x1 = curX1 - parseInt(x1.substring(1)); }
+		}
+		if (x1 < 0 || x1 > 128) {
+			console.log("CLAMPING X1 POSITION. XPOS ("+x1+") OUT OF BOUNDS. 0-128 EXPECTED.");
+			x1 = Math.max(0, Math.min(x1, 128));
+		}
+		// X2
+		if (x2 == undefined) {
+			x2 = curX2;
+		}
+		else {
+			x2 = x2.toString().trim();
+			if (x2 == "" ) { x2 = curX2; }
+			else if (x2.includes("+")) { x2 = curX2 + parseInt(x2.substring(1)); }
+			else if (x2.includes("-")) { x2 = curX2 - parseInt(x2.substring(1)); }
+		}
+		if (x2 < 0 || x2 > 128) {
+			console.log("CLAMPING X2 POSITION. xPos ("+x2+") OUT OF BOUNDS. 0-128 EXPECTED.");
+			x2 = Math.max(0, Math.min(x2, 128));
+		}
+		// Y1
+		if (y1 == undefined) {
+			y1 = curY1;
+		}
+		else {
+			y1 = y1.toString().trim();
+			if (y1 == "" ) { y1 = curY1; }
+			else if (y1.includes("+")) { y1 = curY1 + parseInt(y1.substring(1)); }
+			else if (y1.includes("-")) { y1 = curY1 - parseInt(y1.substring(1)); }
+		}
+		if (y1 < 0 || y1 > 128) {
+			console.log("CLAMPING Y1 POSITION. XPOS ("+y1+") OUT OF BOUNDS. 0-128 EXPECTED.");
+			y1 = Math.max(0, Math.min(y1, 128));
+		}
+		// Y2
+		if (y2 == undefined) {
+			y2 = curY2;
+		}
+		else {
+			y2 = y2.toString().trim();
+			if (y2 == "" ) { y2 = curY2; }
+			else if (y2.includes("+")) { y2 = curY2 + parseInt(y2.substring(1)); }
+			else if (y2.includes("-")) { y2 = curY2 - parseInt(y2.substring(1)); }
+		}
+		if (y2 < 0 || y2 > 128) {
+			console.log("CLAMPING Y2 POSITION. xPos ("+y2+") OUT OF BOUNDS. 0-128 EXPECTED.");
+			y2 = Math.max(0, Math.min(y2, 128));
+		}
+
+		console.log ("SETTING TEXTBOX CORNERS TO ("+x1+","+y1+") and ("+x2+","+y2+")");
+		var topPos = Math.min(y1, y2);
+		var leftPos = Math.min(x1, x2);
+		var bottomPos = Math.max(y1, y2);
+		var rightPos = Math.max(x1, x2);
+		var width = rightPos-leftPos;
+		var height = bottomPos-topPos;
+		var lineCount = Math.floor(height/8);
+
+		textboxStyler.activeStyle.textboxWidth = width;
+		textboxStyler.activeStyle.textMinLines = Math.max(1,lineCount);
+		textboxStyler.activeStyle.textMaxLines = Math.max(1,lineCount);
+		textboxStyler.activeStyle.textPaddingY = (height - (textboxStyler.activeStyle.textMinLines*8)) / 2;
+		textboxStyler.activeStyle.textboxMarginY = topPos;
+		textboxStyler.activeStyle.textboxMarginX = leftPos;
+		textboxStyler.activeStyle.verticalPosition = "top";
+		textboxStyler.activeStyle.horizontalPosition = "left";
+
+		textboxStyler.updateTextbox();
+	},
+	// Updates parameters of the textbox based on style settings.
+	// TODO: see if you can re-render existing textbox content in new style?
+	updateTextbox: function () {
+		textboxInfo.width = textboxStyler.activeStyle.textboxWidth;
+		//textboxInfo.height = textboxStyler.activeStyle.textPaddingY + textboxStyler.activeStyle.borderHeight - 2 + (2 * textboxStyler.activeStyle.textMinLines);
+		textboxInfo.top = textboxStyler.activeStyle.textboxMarginY;
+		textboxInfo.left = textboxStyler.activeStyle.textboxMarginX;
+		textboxInfo.bottom = textboxStyler.activeStyle.textboxMarginY;
+		textboxInfo.font_scale = textboxStyler.activeStyle.textScale/4;
+		textboxInfo.padding_vert = textboxStyler.activeStyle.textPaddingY;
+		textboxInfo.padding_horz = textboxStyler.activeStyle.textPaddingX;
+		textboxInfo.arrow_height = textboxStyler.activeStyle.textPaddingY + textboxStyler.activeStyle.borderHeight - 4;
+
+		pixelsPerRow = (textboxStyler.activeStyle.textboxWidth*2) - (textboxStyler.activeStyle.borderWidth*2) - (textboxStyler.activeStyle.textPaddingX*2);
+
+		textboxInfo.img = ctx.createImageData(textboxInfo.width*scale, textboxInfo.height*scale);
+	},
+	// Draw border to the background of the textbox image, before rendering text or arrows.
+	drawBorder: function () {
+		// console.log ("DRAWING TEXTBOX BORDER");
+		// Iterates through each pixel of the textbox, and determines if a border pixel should be drawn.
+		// Compares 1D array of textbox pixels to 1D arrays for each border sprite, to determine whether to draw a pixel.
+		for (var y = 0; y < (4/textboxStyler.activeStyle.borderScale)*textboxInfo.height; y++) {
+			for (var x = 0; x < (4/textboxStyler.activeStyle.borderScale)*textboxInfo.width; x++) {
+				// NOTE: borderXId and borderYId translate message box coordinates to border tile coordinates.
+				// Use modulo to translate textbox space into tiles, for drawing borders pixel-by-pixel.
+				// For bottom/right borders, border sprites should be anchored to the bottom/right instead.
+				// borderYId and borderXId get pixel coordinates anchored to the top or left
+				// borderDId and borderRId get pixel coordinates anchored to down or right (for right/bottom edges)
+				var borderYId = (y % textboxStyler.activeStyle.borderHeight);
+				var borderXId = (x % textboxStyler.activeStyle.borderWidth);
+				var borderDId = ((y+((4/textboxStyler.activeStyle.borderScale)*textboxInfo.height)) % textboxStyler.activeStyle.borderHeight);
+				var borderRId = ((x+((4/textboxStyler.activeStyle.borderScale)*textboxInfo.width)) % textboxStyler.activeStyle.borderWidth);
+				
+				// NOTE: There's a weird bug with odd vs even textbox heights. Here's a hacky fix for now.
+				// TODO: Handle decimal heights? Still bugs with those (may come up with bitsy's text scaling)
+				if (textboxInfo.height % textboxStyler.activeStyle.borderScale != 0) {
+					borderDId = ((y-4+((4/textboxStyler.activeStyle.borderScale)*textboxInfo.height)) % textboxStyler.activeStyle.borderHeight);
+				} 
+
+				// Calculates index in the 1D array of the border sprite.
+				var borderPxl = (borderYId*textboxStyler.activeStyle.borderWidth) + borderXId;
+				var bottomPxl = (borderDId*textboxStyler.activeStyle.borderWidth) + borderXId;
+				var rightPxl = (borderYId*textboxStyler.activeStyle.borderWidth) + borderRId;
+				var bottomRightPxl = (borderDId*textboxStyler.activeStyle.borderWidth) + borderRId;
+
+				// Determines if the current pixel is along one of the textbox's edges, or if it's in the center.
+				var borderTop = y < textboxStyler.activeStyle.borderHeight;
+				var borderBottom = y >= textboxInfo.height*(4/textboxStyler.activeStyle.borderScale)-textboxStyler.activeStyle.borderHeight;
+				var borderLeft = x < textboxStyler.activeStyle.borderWidth;
+				var borderRight = x >= textboxInfo.width*(4/textboxStyler.activeStyle.borderScale)-textboxStyler.activeStyle.borderWidth;
+
+				// Does this pixel is draw???
+				// 1= draw a border pixel, 0= No! Draw a border bg pixel instead
+				var borderDraw;
+
+				// Retrieve pixel data from appropriate sprite. Special handling for bottom/right borders!
+				if (borderBottom) {
+					// Bottom Left Corner
+					if (borderLeft) { borderDraw = textboxStyler.activeStyle.borderDL[bottomPxl]; }
+					// Bottom Right Corner
+					else if (borderRight) { borderDraw = textboxStyler.activeStyle.borderDR[bottomRightPxl]; }
+					// Bottom Middle Edge
+					else { borderDraw = textboxStyler.activeStyle.borderD[bottomPxl]; }
+				}
+				else if (borderTop) {
+					// Top Left Corner
+					if (borderLeft) { borderDraw = textboxStyler.activeStyle.borderUL[borderPxl]; }
+					// Top Right Corner
+					else if (borderRight) { borderDraw = textboxStyler.activeStyle.borderUR[rightPxl]; }
+					// Top Middle Edge
+					else { borderDraw = textboxStyler.activeStyle.borderU[borderPxl]; }
+				}
+				// Left Edge
+				else if (borderLeft) { borderDraw = textboxStyler.activeStyle.borderL[borderPxl]; }
+				// Right Edge
+				else if (borderRight) { borderDraw = textboxStyler.activeStyle.borderR[rightPxl]; }
+				// Middle
+				else { borderDraw = textboxStyler.activeStyle.borderM[borderPxl]; }
+
+				//scaling shenanigans (maps sprite scale pixels to bitsy/screen-scale pixels)
+				for (var sy = 0; sy < textboxStyler.activeStyle.borderScale; sy++) {
+					for (var sx = 0; sx < textboxStyler.activeStyle.borderScale; sx++) {
+						var pxl = 4 * ( (((textboxStyler.activeStyle.borderScale*y)+sy) * (4*textboxInfo.width)) + (textboxStyler.activeStyle.borderScale*x)+sx );
+
+						// If it's a border pixel, Retrieves RGBA values for the border, and draws it.
+						if (borderDraw) {
+							if (borderTop || borderBottom || borderLeft || borderRight) {
+								textboxInfo.img.data[pxl+0] = textboxStyler.activeStyle.borderColor[0];
+								textboxInfo.img.data[pxl+1] = textboxStyler.activeStyle.borderColor[1];
+								textboxInfo.img.data[pxl+2] = textboxStyler.activeStyle.borderColor[2];
+								textboxInfo.img.data[pxl+3] = textboxStyler.activeStyle.borderColor[3];
+							}
+							else {
+								textboxInfo.img.data[pxl+0] = textboxStyler.activeStyle.borderMidColor[0];
+								textboxInfo.img.data[pxl+1] = textboxStyler.activeStyle.borderMidColor[1];
+								textboxInfo.img.data[pxl+2] = textboxStyler.activeStyle.borderMidColor[2];
+								textboxInfo.img.data[pxl+3] = textboxStyler.activeStyle.borderMidColor[3];
+							}
+							//DEBUG COLORS. UNCOMMENT TO DRAW PIXELS BASED ON TEXTBOX COORDINATES, 0-255
+							/*textboxInfo.img.data[pxl+0] = 204-(x);
+							textboxInfo.img.data[pxl+1] = 204-(x+y);
+							textboxInfo.img.data[pxl+2] = 204-(y*2);
+							textboxInfo.img.data[pxl+3] = 255;
+							//DRAWS TOP-LEFT-ANCHORED GRID TILE COORDINATES IN GREY
+							if (y % borderHeight == 0 || x % borderWidth == 0) {
+								textboxInfo.img.data[pxl+0] = 128;
+								textboxInfo.img.data[pxl+1] = 128;
+								textboxInfo.img.data[pxl+2] = 128;
+								textboxInfo.img.data[pxl+3] = 255;
+							}*/
+						}
+						// If it's a border BG pixel, gets RGBA colors based on if it's on an edge or in middle.
+						else {
+							if (borderTop || borderBottom || borderLeft || borderRight) {
+								textboxInfo.img.data[pxl+0] = textboxStyler.activeStyle.borderBGColor[0];
+								textboxInfo.img.data[pxl+1] = textboxStyler.activeStyle.borderBGColor[1];
+								textboxInfo.img.data[pxl+2] = textboxStyler.activeStyle.borderBGColor[2];
+								textboxInfo.img.data[pxl+3] = textboxStyler.activeStyle.borderBGColor[3];
+							}
+							else {
+								textboxInfo.img.data[pxl+0] = textboxStyler.activeStyle.textboxColor[0];
+								textboxInfo.img.data[pxl+1] = textboxStyler.activeStyle.textboxColor[1];
+								textboxInfo.img.data[pxl+2] = textboxStyler.activeStyle.textboxColor[2];
+								textboxInfo.img.data[pxl+3] = textboxStyler.activeStyle.textboxColor[3];
+							}
+							//DEBUG COLORS. UNCOMMENT TO DRAW PIXELS BASED ON TEXTBOX COORDINATES, 0-255
+							/*textboxInfo.img.data[pxl+0] = (x)+102;
+							textboxInfo.img.data[pxl+1] = (x+y);
+							textboxInfo.img.data[pxl+2] = (y*2)+51;
+							textboxInfo.img.data[pxl+3] = 255;
+							//DRAWS TOP-LEFT-ANCHORED GRID COORDINATES IN GREY
+							if (y % borderHeight == 0 || x % borderWidth == 0) {
+								textboxInfo.img.data[pxl+0] = 76;
+								textboxInfo.img.data[pxl+1] = 76;
+								textboxInfo.img.data[pxl+2] = 76;
+								textboxInfo.img.data[pxl+3] = 255;
+							}*/
+						}
+					}
+				}
+			}
+		}
+	},
+};
+
+exports.hackOptions = hackOptions;
+
+}(this.hacks.textbox_styler = this.hacks.textbox_styler || {}, window));

--- a/src/edit room from dialog.js
+++ b/src/edit room from dialog.js
@@ -1,0 +1,1267 @@
+/**
+🏠
+@file edit room from dialog
+@summary modify the content of a room from dialog
+@license MIT
+@version 1.0.0
+@requires Bitsy Version: 6.1
+@author Dana Holdampf
+
+@description
+This hack allows you to add, remove, or reposition tiles, sprites, and items.
+
+HOW TO USE:
+1. Copy-paste this script into a script tag after the bitsy source
+2. Use the following dialog tags to edit a room's tiles, sprites, or items
+
+-- DRAW DIALOG TAG REFERENCE -----------------------------------
+
+{draw "type, source, x, y, room"}
+{drawNow "type, source, x, y, room"}
+{drawBox "type, source, x1, y1, x2, y2 room"}
+{drawBoxNow "type, source, x1, y1, x2, y2 room"}
+{drawAll "type, source, room"}
+{drawAllNow "type, source, room"}
+
+Information:
+- "draw" creates a tile, item, or sprite at a location in a room. Can be a fixed position, or relative to the player.
+- "drawBox" is as above, but draws tiles, items, or sprites in a box/line, defined by a top left and bottom right corner.
+- "drawAll" is as above, but affects an entire room.
+- Adding "Now" causes it to draw immediately, rather than waiting until the dialog ends.
+
+Parameters:
+- type:		Type of room contents to draw (TIL, ITM, or SPR)
+			Tile (TIL): Each location can have only one Tile. Drawing over an existing tile replaces it.
+			Item (ITM): Multiple items can exist in one spot, but only the most recent item is picked up.
+			Sprite (SPR): Only one copy of each Sprite can exist at a time; redrawing a sprite moves it.
+- source:	The ID (number/letter) of the tile, item, or sprite to draw.
+- x, y:		The x and y coordinates you want to draw at, from 0-15.
+- x1, y1:	(For drawBox only) The x and y coordinates of the top left tile you want to draw on, from 0-15.
+- x2, y2:	(For drawBox only) The x and y coordinates of the bottom right tile you want to draw on, from 0-15.
+			Put + or - before any coordinate to draw relative to the player's current position. (ex. +10, -2, etc.).
+			Leave any coordinate blank (or use +0) to use the player's current X (or Y) position. (If blank, still add commas)
+- room:		The ID (number/letter) of the room you're drawing in. (Refer to Game Data tab for Room IDs)
+			Leave blank to default to modifying the room the player is currently in.
+
+-- ERASE DIALOG TAG REFERENCE ----------------------------------
+
+{erase "type, target, x, y, room"}
+{eraseNow "type, target, x, y, room"}
+{eraseBox "type, target, x1, y1, x2, y2 room"}
+{eraseBoxNow "type, target, x1, y1, x2, y2 room"}
+{eraseAll "type, target, room"}
+{eraseAllNow "type, target, room"}
+
+Information:
+- "erase" Removes tiles, items, or sprites at a location in a room. Can be a fixed position, or relative to the player.
+- "eraseBox" is as above, but erases tiles, items, or sprites in a box/line, defined by a top left and bottom right corner.
+- "eraseAll" is as above, but affects an entire room.
+- Adding "Now" causes it to erase immediately, rather than waiting until the dialog ends.
+
+Parameters:
+- type:		Type of room contents to erase (ANY, TIL, ITM, or SPR)
+			Anything (ANY): Erasing anything will target all valid Tiles, Items, and Sprites.
+			Tile (TIL): Erasing a Tile causes that location to be empty and walkable.
+			Item (ITM): Erasing an Item affects all valid target items, even if there are more than one.
+			Sprite (SPR): Erasing a Sprite removes it from a room, but it will remember dialog progress, etc.
+			Leaving this blank will default to targeting ANY. (If blank, still include commas)
+- target:	The ID (number/letter) of the tile, item, or sprite to erase. Other objects will not be erased.
+			Leave this blank, or set this to "ANY", to target all tiles, items, and/or sprites. (If blank, still include commas)
+- x, y:		The x and y coordinates you want to erase at, from 0-15.
+- x1, y1:	(For eraseBox only) The x and y coordinates of the top left tile you want to erase at, from 0-15.
+- x2, y2:	(For eraseBox only) The x and y coordinates of the bottom right tile you want to erase at, from 0-15.
+			Leave X (or Y) blank to use the player's current X (or Y) position. (If blank, still include commas)
+			Put + or - before the number to erase relative to the player's current position. (ex. +10, -2, etc.).
+- room:		The ID (number/letter) of the room you're erasing in. (Refer to Game Data tab for Room IDs)
+			Leave blank to default to modifying the room the player is currently in.
+
+-- REPLACE DIALOG TAG REFERENCE --------------------------------
+
+{replace "targetType, targetId, newType, newId, x, y, room"}
+{replaceNow "targetType, targetId, newType, newId, x, y, room"}
+{replaceBox "targetType, targetId, newType, newId, x1, y1, x2, y2 room"}
+{replaceBoxNow "targetType, targetId, newType, newId, x1, y1, x2, y2 room"}
+{replaceAll "targetType, targetId, newType, newId, room"}
+{replaceAllNow "targetType, targetId, newType, newId, room"}
+
+Information:
+- "replace" Combines erase and draw. Removes tiles, items, or sprites at a location in a room, and replaces each with something new.
+- "replaceBox" is as above, but replaces tiles, items, or sprites in a box/line, defined by a top left and bottom right corner.
+- "replaceAll" is as above, but affects an entire room.
+- Adding "Now" causes it to erase immediately, rather than waiting until the dialog ends.
+
+Parameters:
+- targetType:	Type of room contents to target for replacing (ANY, TIL, ITM, or SPR).
+				Anything (ANY): Targetting anything will target all valid Tiles, Items, and Sprites.
+				Tile (TIL): Replacing a Tile will remove it, leaving behind walkable space.
+				Item (ITM): Replacing an Item affects all valid items, even if there are more than one.
+				Sprite (SPR): Replacing a Sprite removes it from a room, but it will remember dialog progress, etc.
+				Leaving this blank will default to targeting ANY. (If blank, still include commas)
+- targetId:		The ID (number/letter) of the tile, item, or sprite to replace. Other objects will not be replaced.
+				Leave this blank, or set this to "ANY", to target all tiles, items, and/or sprites. (If blank, still include commas)
+- newType:		As above, but defines the type of room contents to replace the target with (TIL, ITM, or SPR).
+				Note: This must be defined, and cannot be left blank.
+- newId:		As above, but defines the ID (number/letter) of the tile, item, or sprite to replace the target with.
+				Note: This must be defined, and cannot be left blank.
+- x, y:			The x and y coordinates you want to replace at, from 0-15.
+- x1, y1:		(For replaceBox only) The x and y coordinates of the top left tile you want to replace at, from 0-15.
+- x2, y2:		(For replaceBox only) The x and y coordinates of the bottom right tile you want to replace at, from 0-15.
+				Leave X (or Y) blank to use the player's current X (or Y) position. (If blank, still include commas)
+				Put + or - before the number to replace relative to the player's current position. (ex. +10, -2, etc.).
+- room:			The ID (number/letter) of the room you're replacing in. (Refer to Game Data tab for Room IDs)
+				Leave blank to default to modifying the room the player is currently in.
+
+-- COPY DIALOG TAG REFERENCE -----------------------------------
+
+{copy "type, target, copyX, copyY, copyRoom, pasteX, pasteY, pasteRoom"}
+{copyNow "type, target, copyX, copyY, copyRoom, pasteX, pasteY, pasteRoom"}
+{copyBox "type, target, copyX1, copyY1, copyX2, copyY2, copyRoom, pasteX, pasteY, pasteRoom"}
+{copyBoxNow "type, target, copyX1, copyY1, copyX2, copyY2, copyRoom, pasteX, pasteY, pasteRoom"}
+{copyAll "type, target, copyRoom, pasteRoom"}
+{copyAllNow "type, target, copyRoom, pasteRoom"}
+
+Information:
+- "copy" find tiles, items, or sprites at a location in a room, and duplicates each at a new location (may be in a different room).
+- "copyBox" is as above, but copies tiles, items, or sprites in a box/line, defined by a top left and bottom right corner.
+- "copyAll" is as above, but affects an entire room.
+- Adding "Now" causes it to copy immediately, rather than waiting until the dialog ends.
+
+Parameters:
+- type:				Type of room contents to target for copying (ANY, TIL, ITM, or SPR).
+					Anything (ANY): Targetting anything will copy all valid Tiles, Items, and Sprites.
+					Tile (TIL): Each location can have only one Tile. Copying over an existing tile replaces it.
+					Item (ITM): Multiple items can exist in one spot, and all valid items will be copied.
+					Sprite (SPR): Only one copy of each Sprite can exist at a time; copying a sprite moves it.
+					Leaving this blank will default to targeting ANY. (If blank, still include commas)
+- target:			The ID (number/letter) of the tile, item, or sprite to copy. Other objects will not be copied.
+					Leave this blank, or set this to "ANY", to target all tiles, items, and/or sprites. (If blank, still include commas)
+- copyX, copyY:		The x and y coordinates you want to copy from, from 0-15.
+- copyX1, copyY1:	(For copyBox only) The x and y coordinates of the top left tile you want to copy from, from 0-15.
+- copyX2, copyY2:	(For copyBox only) The x and y coordinates of the bottom right tile you want to copy from, from 0-15.
+					Leave X (or Y) blank to use the player's current X (or Y) position. (If blank, still include commas)
+					Put + or - before the number to replace relative to the player's current position. (ex. +10, -2, etc.).
+- copyRoom:			The ID (number/letter) of the room you're copying from. (Refer to Game Data tab for Room IDs)
+					Leave blank to default to copy from the room the player is currently in.
+- pasteX, pasteY:	The x and y coordinates you want to paste copied tiles too, from 0-15.
+					For copyBox, this position marks the upper-left corner of the pasted box.
+- pasteRoom:		As above, but marks the ID (number/letter) of the room you're pasting into.
+					Leave blank to default to paste to the room the player is currently in.
+**/
+
+import {
+	addDialogTag,
+	addDeferredDialogTag
+} from './helpers/kitsy-script-toolkit';
+
+// Draws an Item, Sprite, or Tile at a location in a room
+// {draw "mapId, sourceId, xPos, yPos, roomID"}
+// {drawNow "mapId, sourceId, xPos, yPos, roomID"}
+addDialogTag('drawNow', function (environment, parameters, onReturn) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	drawAt(params[0], params[1], params[2], params[3], params[4]);
+	onReturn(null);
+});
+addDeferredDialogTag('draw', function (environment, parameters) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	drawAt(params[0], params[1], params[2], params[3], params[4]);
+});
+
+// As above, but affects a box area, between two corners.
+// {drawBox "mapId, sourceId, x1, y1, x2, y2, roomID"}
+// {drawBoxNow "mapId, sourceId, x1, y1, x2, y2, roomID"}
+addDialogTag('drawBoxNow', function (environment, parameters, onReturn) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	drawBoxAt(params[0], params[1], params[2], params[3], params[4], params[5], params[6]);
+	onReturn(null);
+});
+addDeferredDialogTag('drawBox', function (environment, parameters) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	drawBoxAt(params[0], params[1], params[2], params[3], params[4], params[5], params[6]);
+});
+
+// As above, but affects an entire room.
+// {drawAll "mapId, sourceId, roomID"}
+// {drawAllNow "mapId, sourceId, roomID"}
+addDialogTag('drawAllNow', function (environment, parameters, onReturn) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	drawBoxAt(params[0], params[1], 0, 0, 15, 15, params[2]);
+	onReturn(null);
+});
+addDeferredDialogTag('drawAll', function (environment, parameters) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	drawBoxAt(params[0], params[1], 0, 0, 15, 15, params[2]);
+});
+
+// Removes Items, Sprites, and/or Tiles at a location in a room
+// {erase "mapId, targetId, xPos, yPos, roomID"}
+// {eraseNow "mapId, targetId, xPos, yPos, roomID"}
+addDialogTag('eraseNow', function (environment, parameters, onReturn) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	eraseAt(params[0], params[1], params[2], params[3], params[4]);
+});
+addDeferredDialogTag('erase', function (environment, parameters) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	eraseAt(params[0], params[1], params[2], params[3], params[4]);
+});
+
+// As above, but affects a box area, between two corners.
+// {eraseBox "mapId, targetId, x1, y1, x2, y2, roomID"}
+// {eraseBoxNow "mapId, targetId, x1, y1, x2, y2, roomID"}
+addDialogTag('eraseBoxNow', function (environment, parameters, onReturn) { 
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	eraseBoxAt(params[0], params[1], params[2], params[3], params[4], params[5], params[6]);
+	onReturn(null);
+});
+addDeferredDialogTag('eraseBox', function (environment, parameters) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	eraseBoxAt(params[0], params[1], params[2], params[3], params[4], params[5], params[6]);
+});
+
+// As above, but affects an entire room.
+// {eraseAll "mapId, targetId, roomID"}
+// {eraseAllNow "mapId, targetId, roomID"}
+addDialogTag('eraseAllNow', function (environment, parameters, onReturn) { 
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	eraseBoxAt(params[0], params[1], 0, 0, 15, 15, params[2]);
+	onReturn(null);
+});
+addDeferredDialogTag('eraseAll', function (environment, parameters) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	eraseBoxAt(params[0], params[1], 0, 0, 15, 15, params[2]);
+});
+
+// Converts instances of target Item, Sprite, or Tile at a location in a room into something new
+// {replace "targetMapId, targetId, newMapId, newId, xPos, yPos, roomID"}
+// {replaceNow "targetMapId, targetId, newMapId, newId, xPos, yPos, roomID"}
+addDialogTag('replaceNow', function (environment, parameters, onReturn) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	replaceAt(params[0], params[1], params[2], params[3], params[4], params[5], params[6]);
+});
+addDeferredDialogTag('replace', function (environment, parameters) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	replaceAt(params[0], params[1], params[2], params[3], params[4], params[5], params[6]);
+});
+
+// As above, but affects a box area between two corners.
+// {replaceBox "targetMapId, targetId, newMapId, newId, x1, y1, x2, y2, roomID"}
+// {replaceBoxNow "targetMapId, targetId, newMapId, newId, x1, y1, x2, y2, roomID"}
+addDialogTag('replaceBoxNow', function (environment, parameters, onReturn) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	replaceBoxAt(params[0], params[1], params[2], params[3], params[4], params[5], params[6], params[7], params[8]);
+});
+addDeferredDialogTag('replaceBox', function (environment, parameters) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	replaceBoxAt(params[0], params[1], params[2], params[3], params[4], params[5], params[6], params[7], params[8]);
+});
+
+// As above, but affects an entire room.
+// {replaceAll "targetMapId, targetId, newMapId, roomID"}
+// {replaceAllNow "targetMapId, targetId, newMapId, newId, roomID"}
+addDialogTag('replaceAllNow', function (environment, parameters, onReturn) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	replaceBoxAt(params[0], params[1], params[2], params[3], 0, 0, 15, 15, params[4]);
+});
+addDeferredDialogTag('replaceAll', function (environment, parameters) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	replaceBoxAt(params[0], params[1], params[2], params[3], 0, 0, 15, 15, params[4]);
+});
+
+// Duplicates Items, Sprites, and/or Tiles from one location in a room to another
+// {copy "mapId, targetId, copyX, copyY, copyRoom, pasteX, pasteY, pasteRoom"}
+// {copyNow "mapId, targetId, copyX, copyY, copyRoom, pasteX, pasteY, pasteRoom"}
+addDialogTag('copyNow', function (environment, parameters, onReturn) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	copyAt(params[0], params[1], params[2], params[3], params[4], params[5], params[6], params[7]);
+	onReturn(null);
+});
+addDeferredDialogTag('copy', function (environment, parameters) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	copyAt(params[0], params[1], params[2], params[3], params[4], params[5], params[6], params[7]);
+});
+
+// As above, but copies a box area between two corners, and pastes at a new spot designating the upper-left corner
+// NOTE: positioning the paste coordinates out of bounds will only draw the section overlapping with the room.
+// {copyBox "mapId, targetId, copyX1, copyY1, copyX2, copyY2, copyRoom, pasteX, pasteY, pasteRoom"}
+// {copyBoxNow "mapId, targetId, copyX1, copyY1, copyX2, copyY2, copyRoom, pasteX, pasteY, pasteRoom"}
+addDialogTag('copyBoxNow', function (environment, parameters, onReturn) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	copyBoxAt(params[0], params[1], params[2], params[3], params[4], params[5], params[6], params[7], params[8], params[9]);
+	onReturn(null);
+});
+addDeferredDialogTag('copyBox', function (environment, parameters) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	copyBoxAt(params[0], params[1], params[2], params[3], params[4], params[5], params[6], params[7], params[8], params[9]);
+});
+
+// As above, but affects an entire room.
+// {copyAll "mapId, targetId, copyRoom, pasteRoom"}
+// {copyAllNow "mapId, targetId, copyRoom, pasteRoom"}
+addDialogTag('copyAllNow', function (environment, parameters, onReturn) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	copyBoxAt(params[0], params[1], 0, 0, 15, 15, params[3], 0, 0, params[4]);
+	onReturn(null);
+});
+addDeferredDialogTag('copyAll', function (environment, parameters) {
+	var params = (parameters[0] != undefined) ? parameters[0].split(',') : {undefined};
+	copyBoxAt(params[0], params[1], 0, 0, 15, 15, params[3], 0, 0, params[4]);
+});
+
+function drawAt (mapId, sourceId, xPos, yPos, roomId) {
+	// Trim and sanitize Map ID / Type parameter, and return if not provided.
+	if (mapId == undefined) {
+		console.log("CAN'T DRAW. DRAW TYPE IS UNDEFINED. TIL, ITM, OR SPR EXPECTED.");
+		return;
+	}
+	else {
+		mapId = mapId.toString().trim();
+		if (mapId == "" || !(mapId.toUpperCase() == "TIL" || mapId.toUpperCase() == "ITM" || mapId.toUpperCase() == "SPR")) {
+			console.log("CAN'T DRAW. UNEXPECTED DRAW TYPE ("+mapId+"). TIL, ITM, OR SPR EXPECTED.");
+			return;
+		}
+	}
+
+	// Trim and sanitize Source ID parameter, and return if not provided
+	if (sourceId == undefined) {
+		console.log("CAN'T DRAW. SOURCE ID IS UNDEFINED. TILE, ITEM, OR SPRITE ID EXPECTED.");
+		return;
+	}
+	else {
+		sourceId = sourceId.toString().trim();
+		if (sourceId == "") {
+			console.log("CAN'T DRAW. NO SOURCE ID GIVEN. TILE, ITEM, OR SPRITE ID EXPECTED.");
+			return;
+		}
+	}
+
+	// Trim and sanitize X Position parameter, and set relative positions, even if omitted.
+	if (xPos == undefined) {
+		xPos = player().x;
+	}
+	else {
+		xPos = xPos.toString().trim();
+		if (xPos == "" ) { xPos = player().x; }
+		else if (xPos.includes("+")) { xPos = player().x + parseInt(xPos.substring(1)); }
+		else if (xPos.includes("-")) { xPos = player().x - parseInt(xPos.substring(1)); }
+	}
+	if (xPos < 0 || xPos > 15) {
+		console.log("CAN'T DRAW. X POSITION ("+xPos+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		return;
+	}
+
+	// Trim and sanitize Y Position parameter, and set relative positions, even if omitted
+	if (yPos == undefined) {
+		yPos = player().y;
+	}
+	else {
+		yPos = yPos.toString().trim();
+		if (yPos == "" ) { yPos = player().y; }
+		else if (yPos.includes("+")) { yPos = player().y + parseInt(yPos.substring(1)); }
+		else if (yPos.includes("-")) { yPos = player().y - parseInt(yPos.substring(1)); }
+	}
+	if (yPos < 0 || yPos > 15) {
+		console.log("CAN'T DRAW. Y POSITION ("+yPos+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		return;
+	}
+	
+	// Trim and sanitize Room ID parameter, and set to current room if omitted
+	if (roomId == undefined) {
+		roomId = curRoom;
+	}
+	else {
+		roomId = roomId.toString().trim();
+		if (roomId == "" ) { roomId = curRoom; }
+		else if (room[roomId] == undefined) {
+			console.log("CAN'T DRAW. ROOM ID ("+roomId+") NOT FOUND.")
+			return;
+		}
+	}
+
+	//console.log ("DRAWING "+mapId+" "+sourceId+" at "+xPos+","+yPos+"(Room "+roomId+")");
+
+	if (mapId.toUpperCase() == "TIL") {
+		if (tile[sourceId] != undefined) {
+			room[roomId].tilemap[yPos][xPos] = sourceId;
+		}
+	}
+	else if (mapId.toUpperCase() == "ITM") {
+		if (item[sourceId] != undefined) {
+			var newItem = {
+				id: sourceId,
+				x: xPos,
+				y: yPos
+			};
+			room[roomId].items.push(newItem);
+		}
+	}
+	else if (mapId.toUpperCase() == "SPR") {
+		if (sprite[sourceId] != undefined) {
+			if (sprite[sourceId].id == "A") {
+				console.log("CAN'T TARGET AVATAR. SKIPPING.")
+			}
+			else if (room[roomId] != undefined) {
+				sprite[sourceId].room = roomId;
+				sprite[sourceId].x = xPos;
+				sprite[sourceId].y = yPos;
+			}
+		}
+	}
+}
+
+function drawBoxAt (mapId, sourceId, x1, y1, x2, y2, roomId) {
+	
+	// Trim and sanitize X and Y Positions, and set relative positions if omitted.
+	if (x1 == undefined) {
+		x1 = player().x;
+	}
+	else {
+		x1 = x1.toString().trim();
+		if (x1 == "" ) { x1 = player().x; }
+		else if (x1.includes("+")) { x1 = player().x + parseInt(x1.substring(1)); }
+		else if (x1.includes("-")) { x1 = player().x - parseInt(x1.substring(1)); }
+	}
+	if (x1 < 0 || x1 > 15) {
+		console.log("CLAMPING X1 POSITION. XPOS ("+x1+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		x1 = Math.max(0, Math.min(x1, 15));
+	}
+	// X2
+	if (x2 == undefined) {
+		x2 = player().x;
+	}
+	else {
+		x2 = x2.toString().trim();
+		if (x2 == "" ) { x2 = player().x; }
+		else if (x2.includes("+")) { x2 = player().x + parseInt(x2.substring(1)); }
+		else if (x2.includes("-")) { x2 = player().x - parseInt(x2.substring(1)); }
+	}
+	if (x2 < 0 || x2 > 15) {
+		console.log("CLAMPING X2 POSITION. xPos ("+x2+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		x2 = Math.max(0, Math.min(x2, 15));
+	}
+	// Y1
+	if (y1 == undefined) {
+		y1 = player().y;
+	}
+	else {
+		y1 = y1.toString().trim();
+		if (y1 == "" ) { y1 = player().y; }
+		else if (y1.includes("+")) { y1 = player().y + parseInt(y1.substring(1)); }
+		else if (y1.includes("-")) { y1 = player().y - parseInt(y1.substring(1)); }
+	}
+	if (y1 < 0 || y1 > 15) {
+		console.log("CLAMPING Y1 POSITION. XPOS ("+y1+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		y1 = Math.max(0, Math.min(y1, 15));
+	}
+	// Y2
+	if (y2 == undefined) {
+		y2 = player().y;
+	}
+	else {
+		y2 = y2.toString().trim();
+		if (y2 == "" ) { y2 = player().y; }
+		else if (y2.includes("+")) { y2 = player().y + parseInt(y2.substring(1)); }
+		else if (y2.includes("-")) { y2 = player().y - parseInt(y2.substring(1)); }
+	}
+	if (y2 < 0 || y2 > 15) {
+		console.log("CLAMPING Y2 POSITION. xPos ("+y2+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		y2 = Math.max(0, Math.min(y2, 15));
+	}
+
+	// Calculate which coordinates are the actual top left and bottom right.
+	var topPos = Math.min(y1, y2);
+	var leftPos = Math.min(x1, x2);
+	var bottomPos = Math.max(y1, y2);
+	var rightPos = Math.max(x1, x2);
+
+	for (var xPos = leftPos; xPos <= rightPos; xPos++) {
+		for (var yPos = topPos; yPos <= bottomPos; yPos++) {
+			drawAt(mapId, sourceId, xPos, yPos, roomId);
+		}
+	}
+}
+
+function eraseAt (mapId, targetId, xPos, yPos, roomId) {
+	// Trim and sanitize Map ID / Type parameter, and use any if not provided.
+	if (mapId == undefined) {
+		//console.log("ERASE TYPE IS UNDEFINED. DEFAULTING TO ANY (TIL, ITM, OR SPR).");
+		mapId = "ANY";
+	}
+	else {
+		mapId = mapId.toString().trim();
+		if (mapId == "" || !(mapId.toUpperCase() == "ANY" || mapId.toUpperCase() == "TIL" || mapId.toUpperCase() == "ITM" || mapId.toUpperCase() == "SPR")) {
+			//console.log("UNEXPECTED ERASE TYPE ("+mapId+"). DEFAULTING TO ANY (TIL, ITM, OR SPR).");
+			mapId = "ANY";
+		}
+	}
+
+	// Trim and sanitize Target ID parameter, and use any if not provided
+	if (targetId == undefined) {
+		//console.log("TARGET ID UNDEFINED. DEFAULTING TO ANY (ANYTHING OF VALID TYPE).");
+		targetId = "ANY";
+	}
+	else {
+		targetId = targetId.toString().trim();
+		if (targetId == "") {
+			//console.log("NO TARGET ID GIVEN. DEFAULTING TO ANY (ANYTHING OF VALID TYPE).");
+			targetId = "ANY";
+		}
+		//mapId = (mapId != "" || mapId.toUpperCase() != "ANY") ? mapId : "ANY";
+	}
+
+	// Trim and sanitize X Position parameter, and set relative positions, even if omitted.
+	if (xPos == undefined) {
+		xPos = player().x;
+	}
+	else {
+		xPos = xPos.toString().trim();
+		if (xPos == "" ) { xPos = player().x; }
+		else if (xPos.includes("+")) { xPos = player().x + parseInt(xPos.substring(1)); }
+		else if (xPos.includes("-")) { xPos = player().x - parseInt(xPos.substring(1)); }
+	}
+	if (xPos < 0 || xPos > 15) {
+		console.log("CAN'T DRAW. X POSITION ("+xPos+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		return;
+	}
+
+	// Trim and sanitize Y Position parameter, and set relative positions, even if omitted
+	if (yPos == undefined) {
+		yPos = player().y;
+	}
+	else {
+		yPos = yPos.toString().trim();
+		if (yPos == "" ) { yPos = player().y; }
+		else if (yPos.includes("+")) { yPos = player().y + parseInt(yPos.substring(1)); }
+		else if (yPos.includes("-")) { yPos = player().y - parseInt(yPos.substring(1)); }
+	}
+	if (yPos < 0 || yPos > 15) {
+		console.log("CAN'T DRAW. Y POSITION ("+yPos+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		return;
+	}
+	
+	// Trim and sanitize Room ID parameter, and set to current room if omitted
+	if (roomId == undefined) {
+		roomId = curRoom;
+	}
+	else {
+		roomId = roomId.toString().trim();
+		if (roomId == "" ) { roomId = curRoom; }
+		else if (room[roomId] == undefined) {
+			console.log("CAN'T DRAW. ROOM ID ("+roomId+") NOT FOUND.")
+			return;
+		}
+	}
+
+	//console.log ("REMOVING "+mapId+" "+targetId+" at "+xPos+","+yPos+"(Room "+roomId+")");
+	
+	// If TIL or undefined.
+	if (mapId.toUpperCase() != "ITM" && mapId.toUpperCase() != "SPR") {
+		if (targetId == "ANY" || room[roomId].tilemap[yPos][xPos] == targetId) {
+			room[roomId].tilemap[yPos][xPos] = "0";
+		}
+	}
+	
+	// If ITM or undefined.
+	if (mapId.toUpperCase() != "TIL" && mapId.toUpperCase() != "SPR") {
+		// Iterate backwards through items, to prevent issues with removed indexes
+		for (var i = room[roomId].items.length-1; i >= 0; i--) {
+			var targetItem = room[roomId].items[i];
+			if (targetId == "ANY" || targetId == targetItem.id) {
+				if (targetItem.x == xPos && targetItem.y == yPos) {
+					room[roomId].items.splice(i, 1);
+				}
+			}
+		}
+	}
+	
+	// If SPR or undefined.
+	if (mapId.toUpperCase() != "TIL" && mapId.toUpperCase() != "ITM") {
+		if (targetId == "ANY") {
+			for (i in sprite) {
+				if (sprite[i].id == "A") {
+					console.log("CAN'T TARGET AVATAR. SKIPPING.")
+				}
+				else if (sprite[i].room == roomId && sprite[i].x == xPos && sprite[i].y == yPos) {
+					sprite[i].x = 0;
+					sprite[i].y = 0;
+					sprite[i].room = "default";
+				}
+			}
+		}
+		else if (sprite[targetId] != undefined) {
+			if (sprite[targetId].id == "A") {
+				console.log("CAN'T TARGET AVATAR. SKIPPING.")
+			}
+			else if (sprite[targetId].room == roomId && sprite[targetId].x == xPos && sprite[targetId].y == yPos) {
+				sprite[targetId].x = 0;
+				sprite[targetId].y = 0;
+				sprite[targetId].room = "default";
+			}
+		}
+	}
+}
+
+function eraseBoxAt (mapId, targetId, x1, y1, x2, y2, roomId) {
+	// Trim and sanitize X and Y Positions, and set relative positions if omitted.
+	if (x1 == undefined) {
+		x1 = player().x;
+	}
+	else {
+		x1 = x1.toString().trim();
+		if (x1 == "" ) { x1 = player().x; }
+		else if (x1.includes("+")) { x1 = player().x + parseInt(x1.substring(1)); }
+		else if (x1.includes("-")) { x1 = player().x - parseInt(x1.substring(1)); }
+	}
+	if (x1 < 0 || x1 > 15) {
+		console.log("CLAMPING X1 POSITION. XPOS ("+x1+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		x1 = Math.max(0, Math.min(x1, 15));
+	}
+	// X2
+	if (x2 == undefined) {
+		x2 = player().x;
+	}
+	else {
+		x2 = x2.toString().trim();
+		if (x2 == "" ) { x2 = player().x; }
+		else if (x2.includes("+")) { x2 = player().x + parseInt(x2.substring(1)); }
+		else if (x2.includes("-")) { x2 = player().x - parseInt(x2.substring(1)); }
+	}
+	if (x2 < 0 || x2 > 15) {
+		console.log("CLAMPING X2 POSITION. xPos ("+x2+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		x2 = Math.max(0, Math.min(x2, 15));
+	}
+	// Y1
+	if (y1 == undefined) {
+		y1 = player().y;
+	}
+	else {
+		y1 = y1.trim();
+		if (y1 == "" ) { y1 = player().y; }
+		else if (y1.includes("+")) { y1 = player().y + parseInt(y1.substring(1)); }
+		else if (y1.includes("-")) { y1 = player().y - parseInt(y1.substring(1)); }
+	}
+	if (y1 < 0 || y1 > 15) {
+		console.log("CLAMPING Y1 POSITION. XPOS ("+y1+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		y1 = Math.max(0, Math.min(y1, 15));
+	}
+	// Y2
+	if (y2 == undefined) {
+		y2 = player().y;
+	}
+	else {
+		y2 = y2.toString().trim();
+		if (y2 == "" ) { y2 = player().y; }
+		else if (y2.includes("+")) { y2 = player().y + parseInt(y2.substring(1)); }
+		else if (y2.includes("-")) { y2 = player().y - parseInt(y2.substring(1)); }
+	}
+	if (y2 < 0 || y2 > 15) {
+		console.log("CLAMPING Y2 POSITION. xPos ("+y2+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		y2 = Math.max(0, Math.min(y2, 15));
+	}
+
+	// Calculate which coordinates are the actual top left and bottom right.
+	var topPos = Math.min(y1, y2);
+	var leftPos = Math.min(x1, x2);
+	var bottomPos = Math.max(y1, y2);
+	var rightPos = Math.max(x1, x2);
+
+	for (var xPos = leftPos; xPos <= rightPos; xPos++) {
+		for (var yPos = topPos; yPos <= bottomPos; yPos++) {
+			eraseAt(mapId, targetId, xPos, yPos, roomId);
+		}
+	}
+}
+
+function replaceAt (targetMapId, targetId, newMapId, newId, xPos, yPos, roomId) {
+	// Trim and sanitize Target Map ID / Type parameter, and use any if not provided.
+	if (targetMapId == undefined) {
+		//console.log("TARGET TYPE IS UNDEFINED. DEFAULTING TO ANY (TIL, ITM, OR SPR).");
+		targetMapId = "ANY";
+	}
+	else {
+		targetMapId = targetMapId.toString().trim();
+		if (targetMapId == "" || !(targetMapId.toUpperCase() == "ANY" || targetMapId.toUpperCase() == "TIL" || targetMapId.toUpperCase() == "ITM" || targetMapId.toUpperCase() == "SPR")) {
+			//console.log("UNEXPECTED TARGET TYPE ("+targetMapId+"). DEFAULTING TO ANY (TIL, ITM, OR SPR).");
+			targetMapId = "ANY";
+		}
+	}
+
+	// Trim and sanitize Target ID parameter, and use any if not provided
+	if (targetId == undefined) {
+		//console.log("TARGET ID UNDEFINED. DEFAULTING TO ANY (ANYTHING OF VALID TYPE).");
+		targetId = "ANY";
+	}
+	else {
+		targetId = targetId.toString().trim();
+		if (targetId == "") {
+			//console.log("NO TARGET ID GIVEN. DEFAULTING TO ANY (ANYTHING OF VALID TYPE).");
+			targetId = "ANY";
+		}
+	}
+
+	// Trim and sanitize New Map ID / Type parameter, and return if not provided.
+	if (newMapId == undefined) {
+		console.log("CANNOT REPLACE. REPLACING TYPE IS UNDEFINED. TIL, ITM, OR SPR EXPECTED.");
+		return;
+	}
+	else {
+		newMapId = newMapId.toString().trim();
+		if (newMapId == "" || !(newMapId.toUpperCase() == "TIL" || newMapId.toUpperCase() == "ITM" || newMapId.toUpperCase() == "SPR")) {
+			console.log("CANNOT REPLACE. UNEXPECTED REPLACING TYPE ("+newMapId+"). TIL, ITM, OR SPR EXPECTED.");
+			return;
+		}
+	}
+
+	// Trim and sanitize New Target ID parameter, and return if not provided
+	if (newId == undefined) {
+		console.log("CANNOT REPLACE. NEW TARGET ID UNDEFINED. VALID ID EXPECTED).");
+		return;
+	}
+	else {
+		newId = newId.toString().trim();
+		if (newId == "") {
+			console.log("CANNOT REPLACE. NO NEW TARGET ID GIVEN. VALID ID EXPECTED");
+			return;
+		}
+	}
+
+	// Trim and sanitize X Position parameter, and set relative positions, even if omitted.
+	if (xPos == undefined) {
+		xPos = player().x;
+	}
+	else {
+		xPos = xPos.toString().trim();
+		if (xPos == "" ) { xPos = player().x; }
+		else if (xPos.includes("+")) { xPos = player().x + parseInt(xPos.substring(1)); }
+		else if (xPos.includes("-")) { xPos = player().x - parseInt(xPos.substring(1)); }
+	}
+	if (xPos < 0 || xPos > 15) {
+		console.log("CAN'T REPLACE. X POSITION ("+xPos+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		return;
+	}
+
+	// Trim and sanitize Y Position parameter, and set relative positions, even if omitted
+	if (yPos == undefined) {
+		yPos = player().y;
+	}
+	else {
+		yPos = yPos.toString().trim();
+		if (yPos == "" ) { yPos = player().y; }
+		else if (yPos.includes("+")) { yPos = player().y + parseInt(yPos.substring(1)); }
+		else if (yPos.includes("-")) { yPos = player().y - parseInt(yPos.substring(1)); }
+	}
+	if (yPos < 0 || yPos > 15) {
+		console.log("CAN'T REPLACE. Y POSITION ("+yPos+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		return;
+	}
+	
+	// Trim and sanitize Room ID parameter, and set to current room if omitted
+	if (roomId == undefined) {
+		roomId = curRoom;
+	}
+	else {
+		roomId = roomId.toString().trim();
+		if (roomId == "" ) { roomId = curRoom; }
+		else if (room[roomId] == undefined) {
+			console.log("CAN'T REPLACE. ROOM ID ("+roomId+") NOT FOUND.")
+			return;
+		}
+	}
+
+	//console.log ("REPLACING "+targetMapId+" "+targetId+" at "+xPos+","+yPos+"(Room "+roomId+")");
+	//console.log ("REPLACING WITH "+newMapId+" "+newId);
+	
+	// If TIL or undefined.
+	if (targetMapId.toUpperCase() != "ITM" && targetMapId.toUpperCase() != "SPR") {
+		if (targetId == "ANY" || room[roomId].tilemap[yPos][xPos] == targetId) {
+			room[roomId].tilemap[yPos][xPos] = "0";
+			drawAt(newMapId, newId, xPos, yPos, roomId);
+		}
+	}
+	
+	// If ITM or undefined.
+	if (targetMapId.toUpperCase() != "TIL" && targetMapId.toUpperCase() != "SPR") {
+		// Iterate backwards through items, to prevent issues with removed indexes
+		for (var i = room[roomId].items.length-1; i >= 0; i--) {
+			var targetItem = room[roomId].items[i];
+			if (targetId == "ANY" || targetId == targetItem.id) {
+				if (targetItem.x == xPos && targetItem.y == yPos) {
+					room[roomId].items.splice(i, 1);
+					drawAt(newMapId, newId, xPos, yPos, roomId);
+				}
+			}
+		}
+	}
+	
+	// If SPR or undefined.
+	if (targetMapId.toUpperCase() != "TIL" && targetMapId.toUpperCase() != "ITM") {
+		if (targetId == "ANY") {
+			for (i in sprite) {
+				if (sprite[i].id == "A") {
+					console.log("CAN'T TARGET AVATAR. SKIPPING.")
+				}
+				else if (sprite[i].room == roomId && sprite[i].x == xPos && sprite[i].y == yPos) {
+					sprite[i].x = 0;
+					sprite[i].y = 0;
+					sprite[i].room = "default";
+					drawAt(newMapId, newId, xPos, yPos, roomId);
+				}
+			}
+		}
+		else if (sprite[targetId] != undefined) {
+			if (sprite[targetId] != "A" && sprite[targetId].room == roomId && sprite[targetId].x == xPos && sprite[targetId].y == yPos) {
+				sprite[targetId].x = 0;
+				sprite[targetId].y = 0;
+				sprite[targetId].room = "default";
+				drawAt(newMapId, newId, xPos, yPos, roomId);
+			}
+		}
+	}
+}
+
+function replaceBoxAt (targetMapId, targetId, newMapId, newId, x1, y1, x2, y2, roomId) {
+	// Trim and sanitize X and Y Positions, and set relative positions if omitted.
+	if (x1 == undefined) {
+		x1 = player().x;
+	}
+	else {
+		x1 = x1.toString().trim();
+		if (x1 == "" ) { x1 = player().x; }
+		else if (x1.includes("+")) { x1 = player().x + parseInt(x1.substring(1)); }
+		else if (x1.includes("-")) { x1 = player().x - parseInt(x1.substring(1)); }
+	}
+	if (x1 < 0 || x1 > 15) {
+		console.log("CLAMPING X1 POSITION. XPOS ("+x1+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		x1 = Math.max(0, Math.min(x1, 15));
+	}
+	// X2
+	if (x2 == undefined) {
+		x2 = player().x;
+	}
+	else {
+		x2 = x2.toString().trim();
+		if (x2 == "" ) { x2 = player().x; }
+		else if (x2.includes("+")) { x2 = player().x + parseInt(x2.substring(1)); }
+		else if (x2.includes("-")) { x2 = player().x - parseInt(x2.substring(1)); }
+	}
+	if (x2 < 0 || x2 > 15) {
+		console.log("CLAMPING X2 POSITION. xPos ("+x2+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		x2 = Math.max(0, Math.min(x2, 15));
+	}
+	// Y1
+	if (y1 == undefined) {
+		y1 = player().y;
+	}
+	else {
+		y1 = y1.toString().trim();
+		if (y1 == "" ) { y1 = player().y; }
+		else if (y1.includes("+")) { y1 = player().y + parseInt(y1.substring(1)); }
+		else if (y1.includes("-")) { y1 = player().y - parseInt(y1.substring(1)); }
+	}
+	if (y1 < 0 || y1 > 15) {
+		console.log("CLAMPING Y1 POSITION. XPOS ("+y1+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		y1 = Math.max(0, Math.min(y1, 15));
+	}
+	// Y2
+	if (y2 == undefined) {
+		y2 = player().y;
+	}
+	else {
+		y2 = y2.toString().trim();
+		if (y2 == "" ) { y2 = player().y; }
+		else if (y2.includes("+")) { y2 = player().y + parseInt(y2.substring(1)); }
+		else if (y2.includes("-")) { y2 = player().y - parseInt(y2.substring(1)); }
+	}
+	if (y2 < 0 || y2 > 15) {
+		console.log("CLAMPING Y2 POSITION. xPos ("+y2+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		y2 = Math.max(0, Math.min(y2, 15));
+	}
+
+	// Calculate which coordinates are the actual top left and bottom right.
+	var topPos = Math.min(y1, y2);
+	var leftPos = Math.min(x1, x2);
+	var bottomPos = Math.max(y1, y2);
+	var rightPos = Math.max(x1, x2);
+
+	for (var xPos = leftPos; xPos <= rightPos; xPos++) {
+		for (var yPos = topPos; yPos <= bottomPos; yPos++) {
+			replaceAt(targetMapId, targetId, newMapId, newId, xPos, yPos, roomId);
+		}
+	}
+}
+
+function copyAt (mapId, targetId, copyXPos, copyYPos, copyRoomId, pasteXPos, pasteYPos, pasteRoomId) {
+	// Trim and sanitize Target Map ID / Type parameter, and use any if not provided.
+	if (mapId == undefined) {
+		//console.log("TARGET TYPE IS UNDEFINED. DEFAULTING TO ANY (TIL, ITM, OR SPR).");
+		mapId = "ANY";
+	}
+	else {
+		mapId = mapId.toString().trim();
+		if (mapId == "" || !(mapId.toUpperCase() == "ANY" || mapId.toUpperCase() == "TIL" || mapId.toUpperCase() == "ITM" || mapId.toUpperCase() == "SPR")) {
+			//console.log("UNEXPECTED TARGET TYPE ("+mapId+"). DEFAULTING TO ANY (TIL, ITM, OR SPR).");
+			mapId = "ANY";
+		}
+	}
+
+	// Trim and sanitize Target ID parameter, and use any if not provided
+	if (targetId == undefined) {
+		//console.log("TARGET ID UNDEFINED. DEFAULTING TO ANY (ANYTHING OF VALID TYPE).");
+		targetId = "ANY";
+	}
+	else {
+		targetId = targetId.toString().trim();
+		if (targetId == "") {
+			//console.log("NO TARGET ID GIVEN. DEFAULTING TO ANY (ANYTHING OF VALID TYPE).");
+			targetId = "ANY";
+		}
+	}
+
+	// Trim and sanitize Copy Position parameters, and set relative positions, even if omitted.
+	if (copyXPos == undefined) {
+		copyXPos = player().x;
+	}
+	else {
+		copyXPos = copyXPos.toString().trim();
+		if (copyXPos == "" ) { copyXPos = player().x; }
+		else if (copyXPos.includes("+")) { copyXPos = player().x + parseInt(copyXPos.substring(1)); }
+		else if (copyXPos.includes("-")) { copyXPos = player().x - parseInt(copyXPos.substring(1)); }
+	}
+	if (copyXPos < 0 || copyXPos > 15) {
+		console.log("CAN'T COPY. X POSITION ("+copyXPos+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		return;
+	}
+
+	if (copyYPos == undefined) {
+		copyYPos = player().y;
+	}
+	else {
+		copyYPos = copyYPos.toString().trim();
+		if (copyYPos == "" ) { copyYPos = player().y; }
+		else if (copyYPos.includes("+")) { copyYPos = player().y + parseInt(copyYPos.substring(1)); }
+		else if (copyYPos.includes("-")) { copyYPos = player().y - parseInt(copyYPos.substring(1)); }
+	}
+	if (copyYPos < 0 || copyYPos > 15) {
+		console.log("CAN'T COPY. Y POSITION ("+copyYPos+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		return;
+	}
+	
+	if (copyRoomId == undefined) {
+		copyRoomId = curRoom;
+	}
+	else {
+		copyRoomId = copyRoomId.trim();
+		if (copyRoomId == "" ) { copyRoomId = curRoom; }
+		else if (room[copyRoomId] == undefined) {
+			console.log("CAN'T COPY. ROOM ID ("+copyRoomId+") NOT FOUND.")
+			return;
+		}
+	}
+
+	// Trim and sanitize Paste Position parameters, and set relative positions, even if omitted.
+	if (pasteXPos == undefined) {
+		pasteXPos = player().x;
+	}
+	else {
+		pasteXPos = pasteXPos.toString().trim();
+		if (pasteXPos == "" ) { pasteXPos = player().x; }
+		else if (pasteXPos.includes("+")) { pasteXPos = player().x + parseInt(pasteXPos.substring(1)); }
+		else if (pasteXPos.includes("-")) { pasteXPos = player().x - parseInt(pasteXPos.substring(1)); }
+	}
+	if (pasteXPos < 0 || pasteXPos > 15) {
+		console.log("CAN'T PASTE. X POSITION ("+pasteXPos+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		return;
+	}
+
+	if (pasteYPos == undefined) {
+		pasteYPos = player().y;
+	}
+	else {
+		pasteYPos = pasteYPos.toString().trim();
+		if (pasteYPos == "" ) { pasteYPos = player().y; }
+		else if (pasteYPos.includes("+")) { pasteYPos = player().y + parseInt(pasteYPos.substring(1)); }
+		else if (pasteYPos.includes("-")) { pasteYPos = player().y - parseInt(pasteYPos.substring(1)); }
+	}
+	if (pasteYPos < 0 || pasteYPos > 15) {
+		console.log("CAN'T PASTE. Y POSITION ("+pasteYPos+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		return;
+	}
+	
+	if (pasteRoomId == undefined) {
+		pasteRoomId = curRoom;
+	}
+	else {
+		pasteRoomId = pasteRoomId.toString().trim();
+		if (pasteRoomId == "" ) { pasteRoomId = curRoom; }
+		else if (room[pasteRoomId] == undefined) {
+			console.log("CAN'T PASTE. ROOM ID ("+pasteRoomId+") NOT FOUND.")
+			return;
+		}
+	}
+
+	//console.log ("COPYING "+mapId+" "+targetId+" at "+copyXPos+","+copyYPos+"(Room "+copyRoomId+")");
+	//console.log ("PASTING AT "+pasteXPos+","+pasteYPos+"(Room "+pasteRoomId+")");
+	
+	// If TIL or undefined.
+	if (mapId.toUpperCase() != "ITM" && mapId.toUpperCase() != "SPR") {
+		if (targetId == "ANY" || room[copyRoomId].tilemap[copyYPos][copyXPos] == targetId) {
+			var copyId = room[copyRoomId].tilemap[copyYPos][copyXPos];
+			drawAt("TIL", copyId, pasteXPos, pasteYPos, pasteRoomId);
+		}
+	}
+	
+	// If ITM or undefined.
+	if (mapId.toUpperCase() != "TIL" && mapId.toUpperCase() != "SPR") {
+		// Iterate backwards through items, to prevent issues with removed indexes
+		for (var i = room[copyRoomId].items.length-1; i >= 0; i--) {
+			var targetItem = room[copyRoomId].items[i];
+			if (targetId == "ANY" || targetId == targetItem.id) {
+				if (targetItem.x == copyXPos && targetItem.y == copyYPos) {
+					drawAt("ITM", targetItem.id, pasteXPos, pasteYPos, pasteRoomId);
+				}
+			}
+		}
+	}
+	
+	// If SPR or undefined.
+	if (mapId.toUpperCase() != "TIL" && mapId.toUpperCase() != "ITM") {
+		if (targetId == "ANY") {
+			for (i in sprite) {
+				if (sprite[i].id == "A") {
+					console.log("CAN'T TARGET AVATAR. SKIPPING.")
+				}
+				else if (sprite[i].room == copyRoomId && sprite[i].x == copyXPos && sprite[i].y == copyYPos) {
+					var copyId = sprite[i].id;
+					drawAt("SPR", copyId, pasteXPos, pasteYPos, pasteRoomId);
+				}
+			}
+		}
+		else if (sprite[targetId] != undefined) {
+			if (sprite[targetId] != "A" && sprite[targetId].room == copyRoomId && sprite[targetId].x == copyXPos && sprite[targetId].y == copyYPos) {
+				var copyId = sprite[targetId].id;
+				drawAt("SPR", copyId, pasteXPos, pasteYPos, pasteRoomId);
+			}
+		}
+	}
+}
+
+function copyBoxAt (mapId, targetId, x1, y1, x2, y2, copyRoomId, pasteXPos, pasteYPos, pasteRoomId) {
+	// Trim and sanitize X and Y Positions, and set relative positions if omitted.
+	if (x1 == undefined) {
+		x1 = player().x;
+	}
+	else {
+		x1 = x1.toString().trim();
+		if (x1 == "" ) { x1 = player().x; }
+		else if (x1.includes("+")) { x1 = player().x + parseInt(x1.substring(1)); }
+		else if (x1.includes("-")) { x1 = player().x - parseInt(x1.substring(1)); }
+	}
+	if (x1 < 0 || x1 > 15) {
+		console.log("CLAMPING X1 POSITION. XPOS ("+x1+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		x1 = Math.max(0, Math.min(x1, 15));
+	}
+	// X2
+	if (x2 == undefined) {
+		x2 = player().x;
+	}
+	else {
+		x2 = x2.toString().trim();
+		if (x2 == "" ) { x2 = player().x; }
+		else if (x2.includes("+")) { x2 = player().x + parseInt(x2.substring(1)); }
+		else if (x2.includes("-")) { x2 = player().x - parseInt(x2.substring(1)); }
+	}
+	if (x2 < 0 || x2 > 15) {
+		console.log("CLAMPING X2 POSITION. xPos ("+x2+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		x2 = Math.max(0, Math.min(x2, 15));
+	}
+	// Y1
+	if (y1 == undefined) {
+		y1 = player().y;
+	}
+	else {
+		y1 = y1.toString().trim();
+		if (y1 == "" ) { y1 = player().y; }
+		else if (y1.includes("+")) { y1 = player().y + parseInt(y1.substring(1)); }
+		else if (y1.includes("-")) { y1 = player().y - parseInt(y1.substring(1)); }
+	}
+	if (y1 < 0 || y1 > 15) {
+		console.log("CLAMPING Y1 POSITION. XPOS ("+y1+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		y1 = Math.max(0, Math.min(y1, 15));
+	}
+	// Y2
+	if (y2 == undefined) {
+		y2 = player().y;
+	}
+	else {
+		y2 = y2.toString().trim();
+		if (y2 == "" ) { y2 = player().y; }
+		else if (y2.includes("+")) { y2 = player().y + parseInt(y2.substring(1)); }
+		else if (y2.includes("-")) { y2 = player().y - parseInt(y2.substring(1)); }
+	}
+	if (y2 < 0 || y2 > 15) {
+		console.log("CLAMPING Y2 POSITION. xPos ("+y2+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		y2 = Math.max(0, Math.min(y2, 15));
+	}
+
+	// Trim and sanitize Target Map ID / Type parameter, and use any if not provided.
+	if (mapId == undefined) {
+		//console.log("TARGET TYPE IS UNDEFINED. DEFAULTING TO ANY (TIL, ITM, OR SPR).");
+		mapId = "ANY";
+	}
+	else {
+		mapId = mapId.toString().trim();
+		if (mapId == "" || !(mapId.toUpperCase() == "ANY" || mapId.toUpperCase() == "TIL" || mapId.toUpperCase() == "ITM" || mapId.toUpperCase() == "SPR")) {
+			//console.log("UNEXPECTED TARGET TYPE ("+mapId+"). DEFAULTING TO ANY (TIL, ITM, OR SPR).");
+			mapId = "ANY";
+		}
+	}
+
+	// Trim and sanitize Target ID parameter, and use any if not provided
+	if (targetId == undefined) {
+		//console.log("TARGET ID UNDEFINED. DEFAULTING TO ANY (ANYTHING OF VALID TYPE).");
+		targetId = "ANY";
+	}
+	else {
+		targetId = targetId.toString().trim();
+		if (targetId == "") {
+			//console.log("NO TARGET ID GIVEN. DEFAULTING TO ANY (ANYTHING OF VALID TYPE).");
+			targetId = "ANY";
+		}
+	}
+
+	if (copyRoomId == undefined) {
+		copyRoomId = curRoom;
+	}
+	else {
+		copyRoomId = copyRoomId.toString().trim();
+		if (copyRoomId == "" ) { copyRoomId = curRoom; }
+		else if (room[copyRoomId] == undefined) {
+			console.log("CAN'T COPY. ROOM ID ("+copyRoomId+") NOT FOUND.")
+			return;
+		}
+	}
+
+	// Trim and sanitize Paste Position parameters, and set relative positions, even if omitted.
+	if (pasteXPos == undefined) {
+		pasteXPos = player().x;
+	}
+	else {
+		pasteXPos = pasteXPos.toString().trim();
+		if (pasteXPos == "" ) { pasteXPos = player().x; }
+		else if (pasteXPos.includes("+")) { pasteXPos = player().x + parseInt(pasteXPos.substring(1)); }
+		else if (pasteXPos.includes("-")) { pasteXPos = player().x - parseInt(pasteXPos.substring(1)); }
+	}
+	if (pasteXPos < 0 || pasteXPos > 15) {
+		console.log("CAN'T PASTE. X POSITION ("+pasteXPos+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		return;
+	}
+	else {
+		pasteXPos = parseInt(pasteXPos);
+	}
+
+	if (pasteYPos == undefined) {
+		pasteYPos = player().y;
+	}
+	else {
+		pasteYPos = pasteYPos.toString().trim();
+		if (pasteYPos == "" ) { pasteYPos = player().y; }
+		else if (pasteYPos.includes("+")) { pasteYPos = player().y + parseInt(pasteYPos.substring(1)); }
+		else if (pasteYPos.includes("-")) { pasteYPos = player().y - parseInt(pasteYPos.substring(1)); }
+	}
+	if (pasteYPos < 0 || pasteYPos > 15) {
+		console.log("CAN'T PASTE. Y POSITION ("+pasteYPos+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		return;
+	}
+	else {
+		pasteYPos = parseInt(pasteYPos);
+	}
+	
+	if (pasteRoomId == undefined) {
+		pasteRoomId = curRoom;
+	}
+	else {
+		pasteRoomId = pasteRoomId.toString().trim();
+		if (pasteRoomId == "" ) { pasteRoomId = curRoom; }
+		else if (room[pasteRoomId] == undefined) {
+			console.log("CAN'T PASTE. ROOM ID ("+pasteRoomId+") NOT FOUND.")
+			return;
+		}
+	}
+
+	// Calculate which coordinates are the actual top left and bottom right.
+	var topPos = Math.min(y1, y2);
+	var leftPos = Math.min(x1, x2);
+	var bottomPos = Math.max(y1, y2);
+	var rightPos = Math.max(x1, x2);
+	var maxXPos = pasteXPos + (rightPos - leftPos);
+	var maxYPos = pasteYPos + (bottomPos - topPos);
+	var copyIds = [];
+	var copyMaps = [];
+	var copyXs = [];
+	var copyYs = [];
+
+	var colId = -1;
+	var rowId = -1;
+
+	// Store maps and ids to copy
+	for (var xPos = leftPos; xPos <= rightPos; xPos++) {
+		colId = -1;
+		rowId++;
+		for (var yPos = topPos; yPos <= bottomPos; yPos++) {
+			colId++;
+			// If TIL or undefined.
+			if (mapId.toUpperCase() != "ITM" && mapId.toUpperCase() != "SPR") {
+				if (targetId == "ANY" || room[copyRoomId].tilemap[yPos][xPos] == targetId) {
+					copyIds.push(room[copyRoomId].tilemap[yPos][xPos]);
+					copyMaps.push("TIL");
+					copyXs.push(pasteXPos+rowId);
+					copyYs.push(pasteYPos+colId);
+				}
+			}
+			
+			// If ITM or undefined.
+			if (mapId.toUpperCase() != "TIL" && mapId.toUpperCase() != "SPR") {
+				// Iterate backwards through items, to prevent issues with removed indexes
+				for (var i = room[copyRoomId].items.length-1; i >= 0; i--) {
+					var targetItem = room[copyRoomId].items[i];
+					if (targetId == "ANY" || targetId == targetItem.id) {
+						if (targetItem.x == xPos && targetItem.y == yPos) {
+							copyIds.push(targetItem.id);
+							copyMaps.push("ITM");
+							copyXs.push(pasteXPos+xPos-1);
+							copyYs.push(pasteYPos+yPos-1);
+						}
+					}
+				}
+			}
+			
+			// If SPR or undefined.
+			if (mapId.toUpperCase() != "TIL" && mapId.toUpperCase() != "ITM") {
+				if (targetId == "ANY") {
+					for (i in sprite) {
+						if (sprite[i].id == "A") {
+							console.log("CAN'T TARGET AVATAR. SKIPPING.")
+						}
+						else if (sprite[i].room == copyRoomId && sprite[i].x == xPos && sprite[i].y == yPos) {
+							copyIds.push(sprite[i].id);
+							copyMaps.push("SPR");
+							copyXs.push(pasteXPos+xPos-1);
+							copyYs.push(pasteYPos+yPos-1);
+						}
+					}
+				}
+				else if (sprite[targetId] != undefined) {
+					if (sprite[targetId] != "A" && sprite[targetId].room == copyRoomId && sprite[targetId].x == xPos && sprite[targetId].y == yPos) {
+						copyIds.push(sprite[i].id);
+						copyMaps.push("SPR");
+						copyXs.push(pasteXPos+xPos-1);
+						copyYs.push(pasteYPos+yPos-1);
+					}
+				}
+			}
+		}
+	}
+
+	// Paste in from copied arrays, at paste position.
+	for (var i = 0; i <= copyIds.length; i++) {
+		drawAt(copyMaps[i], copyIds[i], copyXs[i], copyYs[i], pasteRoomId);
+	}
+}

--- a/src/palette maps.js
+++ b/src/palette maps.js
@@ -1,0 +1,641 @@
+/**
+🎨
+@file palette maps
+@summary allows color pallettes to be defined on a tile-by-tile basis
+@license MIT
+@version 1.0.0
+@requires Bitsy Version: 6.1
+@author Dana Holdampf
+
+@description
+This hack lets you change the color palette, on a tile-by-tile basis.
+Each tile can use a different palette's background, tile, sprite, and extra colors.
+This can also recolor sprites, changing their palette as they move through a recolored tile.
+
+HOW TO USE:
+1. Copy-paste this script into a script tag after the bitsy source
+2. Edit hackOptions below, as needed
+
+You can use this hack in 3 main ways:
+=====================================
+First, you can define a Palette Map for any room, in the hackOptions below.
+- A Palette Map is a 16-by-16 grid of Palette IDs, separated by commas.
+- This corresponds to what palette each location in that room will be drawn with.
+- The Palette Map will override the room's default background, tile color, sprite color, etc.
+- Values in the Palette Map correspond to the Palette IDs in your Game Data (0, 1, a, etc.).
+- The value "-", or other undefined Palette IDs, will draw using the room's default palette.
+- NOTE: The Palette Map recolors everything, including Sprites and Items drawn at that position.
+
+Second, you can put a Palette Override Tag in the name of any tile, sprite, or item.
+- By default, this tag is #PAL0, #PAL1, #PALa, etc., but this can be changed below.
+- This causes that graphic to always be drawn in the specified Palette's colors.
+- Set prioritizePaletteTag to false in the options, to not have tags override a Palette Map.
+
+Third, you can use included dialog commands, to modify the palette of a room or tile.
+- NOTE: If you know JS, you can also use the JavaScript Dialog Hack to modify palettes.
+
+-- SETTING ROOM'S DEFAULT PALETTE ------------------------------
+
+{palette "id, room"}
+{paletteNow "id, room"}
+
+Information:
+- Sets default palette of a room, without changing it's Palette Map.
+- This is the normal room palette set in the editor, used by tiles with undefined or empty palette ids.
+
+Parameters:
+- id:	The id (letter/number) of the color palette, which will be used as the room's new default palette.
+		See the Game Data tab to reference color palette IDs
+- room:	The id (number/letter) of the room you're editing the palette map for.
+		Leave blank to modify the room the player is currently in.
+
+-- SETTING PALETTE OF A SPECIFIC TILE --------------------------
+
+{tilePalette "id, x, y, room"}
+{tilePaletteNow "id, x, y, room"}
+
+Information:
+- Changes palette used at a coordinate in a room's Palette Map.
+- The Palette Map affects all tiles, items, or sprites at that location.
+
+Parameters:
+- id:	The id (number/letter) of the color palette, which will override the palette used at a given position.
+		Leave this blank to reset a tile's palette, and revert to the room's palette (still include commas).
+		See the Game Data tab to reference color palette IDs
+- x, y:	The x and y coordinates of the target tile you want to change the palette of, from 0-15.
+		Put + or - before a coordinate to target tiles relative to the player's position. (ex. +10, -2).
+		Leave X or Y blank (or use +0) to use the player's current position.
+- room:	The id (number/letter) of the room you're editing the palette map for.
+		Leave blank to modify the room the player is currently in.
+
+-- RESETTING THE PALETTE OF ALL TILES IN A ROOM ----------------
+
+{resetTilePalette "room"}
+{resetTilePaletteNow "room"}
+
+Information:
+- Resets the Palette Map of a room back to the values it had to start.
+- If the room had no default Palette Map defined in the Hack Options, tiles will be set to none.
+
+Parameters:
+- room:	The id (number/letter) of the room you're resetting the palette map for.
+		Leave blank to modify the room the player is currently in.
+
+-- CLEARS THE PALETTE MAP FOR ALL TILES IN A ROOM -------------
+
+{clearTilePalette "roomId"} 
+{clearTilePaletteNow "roomId"}
+
+Information:
+- clears Palette Map data for a room, so all tiles use the room's default.
+
+Parameters:
+- room:	The id (number/letter) of the room you're resetting the palette map for.
+		Leave blank to modify the room the player is currently in.
+
+NOTE: add Now to any command to trigger it mid-dialog. (roomPalNow, tilePalNow, clearPalNow, resetPalNow)
+
+Examples:
+{palette "a,0"} sets the default palette for Room 0 to Palette a, once the dialog is done.
+{paletteNow "2"} immediately sets the default palette for the current room to Palette 2.
+{tilePalette "0,2,4"} sets the Palette Map at coordinates 0,2 in the current room to Palette 0.
+{tilePaletteNow "z,0,0,13"} mid-dialog, sets the Palette Map at 0,0 in Room 13 to use Palette z.
+{resetPalette "4"} resets Room 4's Palette Map to the palette IDs it had when the game started.
+{resetPaletteNow} immediately resets the current room's Palette Map to the value it had at the start.
+{clearPalette} removes Palette Map at all coordinates in the current room, so they use the default palette.
+{clearPaletteNow "a1"} instantly clears Palette Map for Room a1, so all tiles show the default palette.
+
+This hack is designed to be flexible. Here are some ideas for how to use it!
+============================================================================
+- By switching palettes from tile to tile, you can effectively use 2 unique colors per tile.
+- You can palette-swap, allowing you to reuse the same tile or item in many colors.
+- You can recolor areas for visual effects, like differently-lit, smokey, or underwater tiles.
+- Using the dialog tags (or JavaScript) you can recolor an area without needing duplicate rooms.
+*/
+
+import {
+	after,
+	inject,
+	addDialogTag,
+	addDeferredDialogTag
+} from './helpers/kitsy-script-toolkit';
+
+// Once world is parsed, parse the Palette Map data
+after("parseWorld", function() {
+	parsePaletteMaps();
+});
+
+// Do a second pass after drawRoom, to overdraw any tiles that aren't the default palette
+after("drawRoom", function(room,context,frameIndex) {
+	overdrawRecoloredTiles(room,context,frameIndex);
+});
+
+// Implement tags to set a room's Default Palette
+addDialogTag('paletteNow', function (environment, parameters, onReturn) {
+	var params = parameters[0].split(',');
+	setRoomPalette(params[0],params[1]);
+	onReturn(null);
+});
+addDeferredDialogTag('palette', function (environment, parameters) {
+	var params = parameters[0].split(',');
+	setRoomPalette(params[0],params[1]);
+});
+
+// Implement tags to modify a room's Palette Map
+addDialogTag('tilePaletteNow', function (environment, parameters, onReturn) {
+	var params = parameters[0].split(',');
+	setPaletteAt(params[0],params[1],params[2],params[3]);	
+	onReturn(null);
+});
+addDeferredDialogTag('tilePalette', function (environment, parameters) {
+	var params = parameters[0].split(',');
+	setPaletteAt(params[0],params[1],params[2],params[3]);	
+});
+
+// Implement tags to delete a room's Palette Map
+addDialogTag('clearTilePaletteNow', function (environment, parameters, onReturn) {
+	clearPaletteMap(parameters[0]);
+	onReturn(null);
+});
+addDeferredDialogTag('clearTilePalette', function (environment, parameters) {
+	clearPaletteMap(parameters[0]);
+});
+
+// Implement tags to set a reset a room's Palette Map to starting values
+addDialogTag('resetTilePaletteNow', function (environment, parameters, onReturn) {
+	resetPaletteMap(parameters[0]);
+	onReturn(null);
+});
+addDeferredDialogTag('resetTilePalette', function (environment, parameters) {
+	resetPaletteMap(parameters[0]);
+});
+
+export var hackOptions = {
+	paletteTag: '#PAL',
+	// Add this flag to Tile/Sprite/Item Name, followed by a Palette ID (#PAL0, #PALa, etc.)
+	// This tile, sprite, or item will automatically be drawn with that palette.
+	// By default, this will override the room's default palette and the tile palette map.
+	
+	prioritizePaletteTag: true,
+	// Whether the Palette Tag above takes priority over a room's Palette Map, when recoloring a graphic.
+	// If true, Tile/Sprite/Item always uses the palette defined by it's Palette Tag, ignoring Palette Maps.
+	// If false, Tile/Sprite/Item's palette is overridden by a room's Palette Map (whenever not default/"-").
+	
+	paletteMapDefinitions: {
+	// You can define a Palette Map for any room here. Just copy or edit an element from this list.
+	// Each row is a string of Palette IDs, separated by commas. These match the coordinates in the Room.
+	// The Palette IDs in the grid are used to draw Tiles/Sprites/Items, instead of the room's default palette.
+	// The IDs in the Palette Map match the Palette IDs in your Game Data (0, 1, a, z, etc.)
+	// "-", or any ID that doesn't match a Palette ID, use the room's default palette.
+		
+		// This is a blank Palette Map for Room ID 0. It can be edited, copied, or removed.
+		0: [
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+		],
+		// This is a sample Palette Map for Room ID 100. It can be edited, copied, or removed.
+		100: [
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,1,0,0,0,0,1,1,1,1,0,0,0,0,1,-",
+			"-,0,-,-,-,-,-,-,-,-,-,-,-,-,0,-",
+			"-,0,-,-,-,-,-,-,-,-,-,-,-,-,0,-",
+			"-,0,-,-,1,1,0,0,1,1,0,0,-,-,0,-",
+			"-,0,-,-,1,1,0,0,1,1,0,0,-,-,0,-",
+			"-,2,-,-,0,0,1,1,0,0,1,1,-,-,2,-",
+			"-,2,-,-,0,0,1,1,0,0,1,1,-,-,2,-",
+			"-,2,-,-,1,1,0,0,1,1,0,0,-,-,2,-",
+			"-,2,-,-,1,1,0,0,1,1,0,0,-,-,2,-",
+			"-,0,-,-,0,0,1,1,0,0,1,1,-,-,0,-",
+			"-,0,-,-,0,0,1,1,0,0,1,1,-,-,0,-",
+			"-,0,-,-,-,-,-,-,-,-,-,-,-,-,0,-",
+			"-,0,-,-,-,-,-,-,-,-,-,-,-,-,0,-",
+			"-,1,0,0,0,0,3,3,3,3,0,0,0,0,1,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+		],
+		// This is a blank Palette Map for Room ID ZZZ. It can be edited, copied, or removed.
+		ZZZ: [
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+			"-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-",
+		],
+	},
+};
+
+// The "default" Palette Map is applied to all rooms that don't have a Palette Map defined.
+// Normally each coordinate is set to use the Room's Default Palette using "-", but this can be edited.
+// These Palette Maps can be accessed via JS using "paletteMap.roomId[y/row][x/column]"
+var paletteMap = {
+	default: [
+		["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+	]
+};
+
+function isPaletteOverridden (drawing) {
+
+	// Checks if tile/sprite/item's name contains the Palette Override Tag
+	if (drawing.name) {
+		var paletteId = drawing.name.indexOf(hackOptions.paletteTag);
+		if (paletteId != -1) {
+			var p = drawing.name[paletteId+hackOptions.paletteTag.length];
+
+			// returns single digit/character after palette tag, if a valid palette
+			if (palette[p] != undefined) {
+				return p;
+			}
+		}
+		return false; //if palette tag isn't present, returns default character
+	}
+}
+
+// TODO: If it's useful, replace this with a function to set every element of a Palette Map to an ID?
+function clearPaletteMap(roomId) {
+	// Trim and sanitize Room ID parameter, and set to current room if omitted
+	if (roomId == undefined) {
+		roomId = curRoom;
+		//roomId = getRoom().id;
+	}
+	else {
+		roomId = roomId.toString().trim();
+		if (roomId == "" ) { roomId = curRoom; }
+		else if (room[roomId] == undefined) {
+			console.log("CAN'T GET ROOM. ROOM ID ("+roomId+") NOT FOUND.")
+			return;
+		}
+	}
+
+	if (roomId.toLowerCase() == "default") {
+		roomId = "default"
+	}
+	console.log("CLEARING PALETTE MAP FOR ROOM " + roomId);
+
+	paletteMap[roomId] = [
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		];
+}
+
+
+function resetPaletteMap(roomId) {
+	// Trim and sanitize Room ID parameter, and set to current room if omitted
+	if (roomId == undefined) {
+		roomId = curRoom;
+		//roomId = getRoom().id;
+	}
+	else {
+		roomId = roomId.toString().trim();
+		if (roomId == "" ) { roomId = curRoom; }
+		else if (room[roomId] == undefined) {
+			console.log("CAN'T GET ROOM. ROOM ID ("+roomId+") NOT FOUND.")
+			return;
+		}
+	}
+	console.log("RESETTING PALETTE MAP FOR ROOM " + roomId);
+
+	// If given the Default parameter, resets the Default Map, and Returns.
+	if (roomId.toLowerCase() == "default") {
+		paletteMap["default"] = [
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+			["-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-"],
+		];
+		return true;
+	}
+
+	// If it isn't the Default map, Deep Clone a new Palette Map object from it.
+	paletteMap[roomId] = JSON.parse(JSON.stringify(paletteMap["default"])); // Deep Clone the Default object.
+	
+	// If Palette Map for current Room exists in Hack Options, overwrite the new map with this data.
+	if (hackOptions.paletteMapDefinitions[roomId] != undefined) {
+		var newPaletteData = hackOptions.paletteMapDefinitions[roomId];
+		var r = 0;
+
+		newPaletteData.forEach(function (palRow, r) {
+			var palRowArray = palRow.split(",");
+
+			if (palRowArray != undefined) {
+				for (var c = 0; c < palRowArray.length; c++) {
+					
+					// If Palette ID exists and matches a valid Palette, write it.
+					if (palRowArray[c] != undefined && palette[ palRowArray[c] ] != undefined ) {
+						paletteMap[roomId][r][c] = palRowArray[c];
+					}
+					else {
+						paletteMap[roomId][r][c] = "-";
+					}
+				}	
+			}
+		});
+	}
+}
+
+function parsePaletteMaps() {
+	console.log("PARSING PALETTE MAPS");
+
+	for (id in room) { // Initialize Palette Maps for each Room
+		resetPaletteMap(id);
+	}
+}
+
+function setPaletteAt(p,x,y,roomId) {
+	// Trim and sanitize X Position parameter, and set relative positions, even if omitted.
+	if (x == undefined) {
+		x = player().x;
+	}
+	else {
+		x = x.toString().trim();
+		if (x == "" ) { x = player().x; }
+		else if (x.includes("+")) { x = player().x + parseInt(x.substring(1)); }
+		else if (x.includes("-")) { x = player().x - parseInt(x.substring(1)); }
+	}
+	if (x < 0 || x > 15) {
+		console.log("CAN'T SET PALETTE. X POSITION ("+x+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		return;
+	}
+
+	// Trim and sanitize Y Position parameter, and set relative positions, even if omitted
+	if (y == undefined) {
+		y = player().y;
+	}
+	else {
+		y = y.toString().trim();
+		if (y == "" ) { y = player().y; }
+		else if (y.includes("+")) { y = player().y + parseInt(y.substring(1)); }
+		else if (y.includes("-")) { y = player().y - parseInt(y.substring(1)); }
+	}
+	if (y < 0 || y > 15) {
+		console.log("CAN'T SET PALETTE. Y POSITION ("+y+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		return;
+	}
+
+	// Trim and sanitize Room ID parameter, and set to current room if omitted
+	if (roomId == undefined) {
+		roomId = curRoom;
+		//roomId = getRoom().id;
+	}
+	else {
+		roomId = roomId.toString().trim();
+		if (roomId == "" ) { roomId = curRoom; }
+		else if (room[roomId] == undefined) {
+			console.log("CAN'T GET ROOM. ROOM ID ("+roomId+") NOT FOUND.")
+			return;
+		}
+	}
+
+	if (p == undefined) {
+		p = "-";
+	}
+	else if (palette[p] == undefined) {
+		p = "-";
+	}
+	console.log("SET PALETTE AT " + x + "," + y + "(ROOM " + roomId + ") TO " + p);
+	paletteMap[roomId][y][x] = p;
+}
+
+function setRoomPalette (p, roomId) {
+	// Trim and sanitize Room ID parameter, and set to current room if omitted
+	if (roomId == undefined) {
+		roomId = curRoom;
+		//roomId = getRoom().id;
+	}
+	else {
+		roomId = roomId.toString().trim();
+		if (roomId == "" ) { roomId = curRoom; }
+		else if (room[roomId] == undefined) {
+			console.log("CAN'T SET ROOM PALETTE. ROOM ID ("+roomId+") NOT FOUND.")
+			return;
+		}
+	}
+
+	if (p == undefined) {
+		p = "-";
+	}
+	else if (palette[p] == undefined) {
+		p = "-";
+	}
+
+	// If given Palette ID matches an existing Palette, set room palette to that
+	if (palette[p] != undefined ) {
+		console.log("ROOM " + roomId + " DEFAULT PALETTE SET TO " + p);
+		room[roomId].pal = p;
+		return true;
+	}
+	console.log("ROOM " + roomId + " DEFAULT PALETTE CAN'T BE SET TO " + p + "; INVALID PALETTE ID");
+	return false;
+}
+
+function getPaletteAt(x,y,roomId) {
+	// Trim and sanitize X Position parameter, and set relative positions, even if omitted.
+	if (x == undefined) {
+		x = player().x;
+	}
+	else {
+		x = x.toString().trim();
+		if (x == "" ) { x = player().x; }
+		else if (x.includes("+")) { x = player().x + parseInt(x.substring(1)); }
+		else if (x.includes("-")) { x = player().x - parseInt(x.substring(1)); }
+	}
+	if (x < 0 || x > 15) {
+		console.log("CAN'T GET PALETTE. X POSITION ("+x+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		return;
+	}
+
+	// Trim and sanitize Y Position parameter, and set relative positions, even if omitted
+	if (y == undefined) {
+		y = player().y;
+	}
+	else {
+		y = y.toString().trim();
+		if (y == "" ) { y = player().y; }
+		else if (y.includes("+")) { y = player().y + parseInt(y.substring(1)); }
+		else if (y.includes("-")) { y = player().y - parseInt(y.substring(1)); }
+	}
+	if (y < 0 || y > 15) {
+		console.log("CAN'T GET PALETTE. Y POSITION ("+y+") OUT OF BOUNDS. 0-15 EXPECTED.");
+		return;
+	}
+
+	// Trim and sanitize Room ID parameter, and set to current room if omitted
+	if (roomId == undefined) {
+		roomId = curRoom;
+	}
+	else {
+		roomId = roomId.toString().trim();
+		if (roomId == "" ) { roomId = curRoom; }
+		else if (room[roomId] == undefined) {
+			console.log("CAN'T GET ROOM. ROOM ID ("+roomId+") NOT FOUND.")
+			return;
+		}
+	}
+
+	//if (roomId == undefined || room[roomId] == undefined) {
+	//	roomId = getRoom().id;
+	//}
+
+	// Check for Palette Map for the room, if it exists.
+	var p = -1;
+	if (paletteMap[roomId] != undefined) {
+		p = paletteMap[roomId][y][x];
+	}
+
+	// Check for Palette Map for the room, if it exists. Defaults to -1 if undefined.	
+	if (palette[p] == undefined) {
+		p = getRoom().pal;
+	}
+	return p;
+}
+
+function overdrawRecoloredTiles(room,context,frameIndex) {
+	if (!context) { //optional pass in context;
+		context = ctx;
+	}
+	var paletteId = "default";
+
+	// protect against invalid rooms
+	if (room === undefined) {
+		return;
+	}
+	// set default paletteId to room's palette
+	if (room.pal != null && palette[paletteId] != undefined) {
+		paletteId = room.pal;
+	}
+
+	// calculate tile dimensions for drawing recolored backgrounds on empty tiles
+	var tileWidth = canvas.width/16;
+	var tileHeight = canvas.height/16;
+
+	//overdraw any recolored tiles on top of existing room
+	for (var r in room.tilemap) {
+		for (var c in room.tilemap[r]) {
+			
+			var tileTop = r*tileHeight;
+			var tileLeft = c*tileWidth;
+			var tilePaletteId = getPaletteAt(c,r);
+			
+			// skip drawing tile, if it's invalid or already been drawn in default color
+			if (palette[tilePaletteId] != undefined || palette[tilePaletteId] != paletteId) {
+				
+				//draw backgrounds as colored rectangles
+				context.fillStyle = "rgb(" + getPal(tilePaletteId)[0][0] + "," + getPal(tilePaletteId)[0][1] + "," + getPal(tilePaletteId)[0][2] + ")";
+				context.fillRect(tileLeft, tileTop, tileLeft+tileWidth, tileTop+tileHeight);
+
+				var id = room.tilemap[r][c];
+				if (id != "0") {
+					if (tile[id] != null) {
+						// If a tile has the #PAL tag, it overrides the tile's normal palette.
+						if (hackOptions.prioritizePaletteTag) {
+							var paletteOverrideId = isPaletteOverridden(tile[room.tilemap[r][c]]);
+							if (paletteOverrideId) {
+								var tilePaletteId = paletteOverrideId;
+							}
+						}
+						drawTile( getTileImage(tile[id],tilePaletteId,frameIndex), c, r, context );
+					}
+				}				
+			}
+		}
+	}
+
+	//draw items
+	for (var i = 0; i < room.items.length; i++) {
+		var itm = room.items[i];
+
+		var itemPaletteId = getPaletteAt(itm.x,itm.y);
+		if (palette[itemPaletteId] != undefined || palette[itemPaletteId] != paletteId) {
+			if (hackOptions.prioritizePaletteTag) {
+				var paletteOverrideId = isPaletteOverridden(item[itm.id]);
+				if (paletteOverrideId) {
+					itemPaletteId = paletteOverrideId;
+				}
+			}
+			drawItem( getItemImage(item[itm.id],itemPaletteId,frameIndex), itm.x, itm.y, context );		
+		}
+	}
+
+	//draw sprites
+	for (id in sprite) {
+		var spr = sprite[id];
+		if (spr.room === room.id) {
+
+			// Get palette map at sprite's coordinate
+			var spritePaletteId = getPaletteAt(spr.x,spr.y);
+			if (palette[spritePaletteId] != undefined || palette[spritePaletteId] != paletteId) {
+				if (hackOptions.prioritizePaletteTag) {
+					var paletteOverrideId = isPaletteOverridden(spr);
+					if (paletteOverrideId) {
+						spritePaletteId = paletteOverrideId;
+					}
+				}
+			}
+			drawSprite( getSpriteImage(spr,spritePaletteId,frameIndex), spr.x, spr.y, context );
+		}
+	}
+}

--- a/src/textbox styler.js
+++ b/src/textbox styler.js
@@ -1,0 +1,1156 @@
+/**
+📐
+@file textbox styler
+@summary 
+@license MIT
+@version 1.0.0
+@requires Bitsy Version: 6.1
+@author Dana Holdampf & Sean S. LeBlanc
+
+@description
+This hack lets you edit the appearance, position, and other properties of the textbox.
+It lets you draw a border, replace the continue arrow, resize or reposition the box, recolor text or backgrounds, etc.
+You can also use dialog tags to switch styles, or redefine style properties, from a dialog.
+
+NOTE: This hack re-implements the functionality of the Long Dialog hack.
+Since they modify the same code, don't use them both to avoid conflicts!
+Like the Long Dialog hack, it also includes the paragraph break "(p)" dialog tag.
+
+HOW TO USE:
+1. Copy-paste this script into a script tag after the bitsy source
+2. Edit hackOptions below, to define the default textbox style
+3. Optionally, add additional alternate styles to the dialogStyles section
+
+You can define custom style properties for the textbox in the hackOptions below.
+- The topmost options are the default style properties, which are applied to the textbox initially.
+- The dialogStyles section is used for defining alternate styles you can switch between.
+- Use the dialog commands below to switch between styles, or change individual properties.
+
+The Dialog Tags for switching textbox styles are as follows:
+============================================================
+
+-- SWITCH TEXTBOX STYLE, WITH UNDEFINED PROPERTIES BEING IGNORED ---------------
+
+{textStyle "dialogStyle"}
+{textStyleNow "dialogStyle"}
+
+Information:
+- Replaces current textbox style with a new set of style properties, as defined in the dialogStyles below.
+- Only changes style properties that are defined in the dialogStyle. Undefined properties are left unchanged.
+
+Parameters:
+- dialogStyle:	id/name of a dialogStyle, as defined in the hackOptions below. (ex. "vanilla", "centered", "inverted", etc.)
+
+-- SWITCH TEXTBOX STYLE, WITH UNDEFINED PROPERTIES REVERTING TO DEFAULTS -------
+
+{setTextStyle "dialogStyle"}
+{setTextStyleNow "dialogStyle"}
+
+Information:
+- As above, but any undefined style properties in the new dialogStyle revert to the default style properties.
+
+Parameters:
+- dialogStyle:	id/name of a dialog style, as defined in the hackOptions below. (ex. "vanilla", "centered", "inverted", etc.)
+
+-- CHANGE AN INDIVIDUAL TEXTBOX STYLE PROPERTY ---------------------------------
+
+{textProperty "styleProperty, styleValue"}
+{textPropertyNow "styleProperty, styleValue"}
+
+Information:
+- Sets an individual textbox style property, to a given value. See the hackOptions below for valid properties and values.
+
+Parameters:
+- styleProperty:	id/name of a style property, as defined in the hackOptions below. (ex. "borderColor", "textboxWidth", "textSpeed", etc.)
+- styleValue:		value to assign to the styleProperty, as defined in the hackOptions below. (ex. "[128,128,128,256]", "140", etc.)
+
+-- REVERT TEXTBOX STYLE TO THE DEFAULT STYLE -----------------------------------
+
+{resetTextStyle}
+{resetTextStyleNow}
+
+Information:
+- Resets all style properties to the values in the default dialog style, as defined in the hackOptions below.
+
+-- REVERT AN INDIVIDUAL TEXTBOX STYLE PROPERTY TO IT'S DEFAULT VALUE -----------
+
+{resetProperty "styleProperty"}
+{resetPropertyNow "styleProperty"}
+
+Information:
+- Resets an individual style property to it's default value, as defined in the hackOptions below.
+
+Parameters:
+- styleProperty:	id/name of a style property, as defined in the hackOptions below. (ex. "borderColor", "textboxWidth", "textSpeed", etc.)
+
+-- SET OR MODIFY THE POSITION AND SIZE OF THE TEXTBOX TO AN ABSOLUTE VALUE -----
+
+{textPosition "x, y, width, minLines, maxLines"}
+{textPositionNow "x, y, width, minLines, maxLines"}
+
+Information:
+- Repositions and resizes the textbox, at an absolute position based on parameters.
+- Calculates the necessary style properties and spacing for the textbox automatically.
+
+Parameters:
+- x, y:			The x and y coordinates of the top left corner. Measured in bitsy-scale pixels (0-128).
+- width:		The width of the textbox. Measured in bitsy-scale pixels (0-128).
+- minLines: 	The minimum number of lines to display on the textbox. Height resizes automatically.
+- maxLines: 	The maximum number of lines to display on the textbox. Height resizes automatically.
+				If any parameter is left blank, the textbox will use it's current values.
+				If given a +/- value (+8, -40, etc) that value is adjusted relative to it's current value.
+
+----------------------------------------------------------------
+
+DIALOG TAG NOTES:
+- Add "Now" to the end of these dialog tags to make the tag trigger mid-dialog, rather than after the current dialog is concluded.
+- To reset a property or style to default values, you can also set a style or style property value to "default".
+- NOTE: Changing the style after some text is already printed can break existing text.
+- Colors are defined as 4 values, [red,green,blue,alpha], each ranging from 0-255.
+- Alpha is opacity; colors can be translucent by reducing Alpha below 255. 0 is fully transparent.
+
+Examples:
+- {textStyleNow "center"} immediately applies a style defined below, which centers the textbox, without overriding other existing style properties.
+- {setTextStyle "vertical"} after the current dialog ends, switches to a vertical textbox style, defined in dialogStyles.
+- {textPropertyNow "textSpeed, 25"} immediately reduces the time to print each character to 25ms.
+- {resetTextStyle} Once this text is finished, will reset the textbox to the default style.
+- {resetPropertyNow "textScale"} Immediately restores the text scale property to the default setting.
+- {textPosition "8, 8, 120"} Resizes the textbox to cover the entire screen, with 8 pixels of padding on every side.
+
+TODO: For future versions
+- Redraw existing textbox contents in new style, when switching, and then continue.
+- Recalculate textbox's center position, considering textbox margins in center calculation?
+*/
+
+import {
+	inject,
+	addDialogTag,
+	addDeferredDialogTag
+} from './helpers/kitsy-script-toolkit';
+import './paragraph-break';
+
+// Applies only a Style's defined attributes to the current textbox style.
+// {style "StyleName"}
+// {textStyleNow "StyleName"}
+addDialogTag('textStyleNow', function (environment, parameters, onReturn) {
+	textboxStyler.style(parameters[0]);
+	onReturn(null);
+});
+addDeferredDialogTag('textStyle', function (environment, parameters) {
+	textboxStyler.style(parameters[0]);
+});
+
+// Sets the current Style of the textbox (undefined attributes use Defaults instead)
+// {setTextStyle "StyleName"}
+// {setTextStyleNow "StyleName"}
+addDialogTag('setTextStyleNow', function (environment, parameters, onReturn) {
+	textboxStyler.setStyle(parameters[0]);
+	onReturn(null);
+});
+addDeferredDialogTag('setTextStyle', function (environment, parameters) {
+	textboxStyler.setStyle(parameters[0]);
+});
+
+// Applies the current Style of the textbox (undefined attributes use Defaults instead)
+// {textProperty "StyleProperty, StyleValue"}
+// {textPropertyNow "StyleProperty, StyleValue"}
+addDialogTag('textPropertyNow', function (environment, parameters, onReturn) {
+	var params = parameters[0].split(',');
+	textboxStyler.setProperty(params[0], params[1]);
+	onReturn(null);
+});
+addDeferredDialogTag('textProperty', function (environment, parameters) {
+	var params = parameters[0].split(',');
+	textboxStyler.setProperty(params[0], params[1]);
+});
+
+// Resets the Style of the textbox to the Default style.
+// {resetTextStyle}
+// {resetTextStyleNow}
+addDialogTag('resetTextStyleNow', function (environment, parameters, onReturn) {
+	textboxStyler.resetStyle();
+	onReturn(null);
+});
+addDeferredDialogTag('resetTextStyle', function (environment, parameters) {
+	textboxStyler.resetStyle();
+});
+
+// Resets a Style Property of the textbox to it's Default value.
+// {resetTextProperty "StyleProperty"}
+// {resetTextPropertyNow "StyleProperty"}
+addDialogTag('resetTextPropertyNow', function (environment, parameters, onReturn) {
+	textboxStyler.resetProperty(parameters[0]);
+	onReturn(null);
+});
+addDeferredDialogTag('resetTextProperty', function (environment, parameters) {
+	textboxStyler.resetProperty(parameters[0]);
+});
+
+// Repositions and resizes textbox at an absolute position, based on coordinates.
+// {textPosition "x, y, width, minLines, maxLines"}
+// {textPositionNow "x, y, width, minLines, maxLines"}
+addDialogTag('textPositionNow', function (environment, parameters, onReturn) {
+	var params = parameters[0].split(',');
+	textboxStyler.textboxPosition(params[0],params[1],params[2],params[3],params[4]);
+	onReturn(null);
+});
+addDeferredDialogTag('textPosition', function (environment, parameters) {
+	var params = parameters[0].split(',');
+	textboxStyler.textboxPosition(params[0],params[1],params[2],params[3],params[4]);
+});
+
+export var hackOptions = {
+	// Determines where the textbox is positioned. "shift" moves the textbox based on the player's position.
+	verticalPosition: "shift", // options are "top", "center", "bottom", or "shift" (moves based on player position)
+	horizontalPosition: "center", // options are "left", "center", "right", or "shift" (moves based on player position)
+
+	textboxColor: [0,0,0,255], // Colors text and textbox are drawn, in [R,G,B,A]. TODO: Alpha doesn't presently work!
+	textboxWidth: 120, // Width of textbox in pixels. Default 104.
+	textboxMarginX: 4, // Pixels of space outside the left (or right) of the textbox. Default 12.
+	textboxMarginY: 4, // Pixels of space outside the top (or bottom) of the textbox. Default 12.
+
+	textColor: [255,255,255,255], // Default color of text.
+	textMinLines: 2, // Minimum number of rows for text. Determines starting textbox height. Default 2.
+	textMaxLines: 2, // Maximum number of rows for text. Determines max textbox height. Default 2.
+	textScale: 2, // Scaling factor for text. Default 2. Best with 1, 2, or 4.
+	textSpeed: 50, // Time to print each character, in milliseconds. Default 50.
+	textPaddingX: 0, // Default horizontal padding around the text.
+	textPaddingY: 2, // Default vertical padding around the text.
+
+	// Color the continue arrow is drawn using, in [R,G,B,A]
+	arrowColor: [255,255,255,255], // Foreground color of arrow sprite.
+	arrowBGColor: [0,0,0,255], // Background color. If transparent, draws no BG.
+
+	// Position of textbox continue arrow, on bottom of textbox.
+	arrowAlign: "right", // Options are: "right", "center", or "left" aligned
+
+	// Pixels of padding the arrow is inset from the edge by
+	arrowInsetX: 12,
+	arrowInsetY: 0,
+
+	// Should match dimensions of the sprite below
+	arrowWidth: 8, // Width of arrow sprite below, in pixels
+	arrowHeight: 5, // Height of arrow sprite below, in pixels
+	arrowScale: 2, // Scaling factor for arrow sprite. Default 2. Best with 1, 2, or 4.
+
+	// Pixels defining the textbox continue arrow. 1 draws a pixel in main Color, 0 draws in BG Color.
+	arrowSprite: [
+		1,1,1,1,1,1,1,1,
+		0,1,1,1,1,1,1,0,
+		0,0,1,1,1,1,0,0,
+		0,0,0,1,1,0,0,0,
+		0,0,0,0,0,0,0,0
+	],
+	// Colors the borders are drawn using, in [R,G,B,A].
+	borderColor: [128,128,128,255], // Foreground color for border tiles.
+	borderMidColor: [51,51,51,255], // Foreground color used for middle border tiles.
+	borderBGColor: [0,0,0,255], // Background color the border tiles. If transparent, draws no BG.
+	
+	// Border is drawn past the edges of the textbox.
+	// Should match dimensions of the sprite below
+	borderWidth: 8, // Width of border sprites, in pixels. Default 8.
+	borderHeight: 8, // Height of border sprites, in pixels. Default 8.
+	borderScale: 2, // Scaling factor for border sprites. Default 2. Best with 1, 2, or 4.
+	
+	// Pixels defining the corners and edges the border is drawn with. 1 draws a pixel in foreground color, 0 in BG.
+	borderUL: [
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+		0,0,1,1,1,1,1,1,
+		0,0,1,1,1,1,1,1,
+		0,0,1,1,0,0,0,0,
+		0,0,1,1,0,0,0,0,
+		0,0,1,1,0,0,0,0,
+		0,0,1,1,0,0,0,0,
+	],
+	borderU: [
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+		1,1,1,1,1,1,1,1,
+		1,1,1,1,1,1,1,1,
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+	],
+	borderUR: [
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+		1,1,1,1,1,1,0,0,
+		1,1,1,1,1,1,0,0,
+		0,0,0,0,1,1,0,0,
+		0,0,0,0,1,1,0,0,
+		0,0,0,0,1,1,0,0,
+		0,0,0,0,1,1,0,0,
+	],
+	borderL: [
+		0,0,1,1,0,0,0,0,
+		0,0,1,1,0,0,0,0,
+		0,0,1,1,0,0,0,0,
+		0,0,1,1,0,0,0,0,
+		0,0,1,1,0,0,0,0,
+		0,0,1,1,0,0,0,0,
+		0,0,1,1,0,0,0,0,
+		0,0,1,1,0,0,0,0,
+	],
+	borderR: [
+		0,0,0,0,1,1,0,0,
+		0,0,0,0,1,1,0,0,
+		0,0,0,0,1,1,0,0,
+		0,0,0,0,1,1,0,0,
+		0,0,0,0,1,1,0,0,
+		0,0,0,0,1,1,0,0,
+		0,0,0,0,1,1,0,0,
+		0,0,0,0,1,1,0,0,
+	],
+	borderDL: [
+		0,0,1,1,0,0,0,0,
+		0,0,1,1,0,0,0,0,
+		0,0,1,1,0,0,0,0,
+		0,0,1,1,0,0,0,0,
+		0,0,1,1,1,1,1,1,
+		0,0,1,1,1,1,1,1,
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+	],
+	borderD: [
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+		1,1,1,1,1,1,1,1,
+		1,1,1,1,1,1,1,1,
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+	],
+	borderDR: [
+		0,0,0,0,1,1,0,0,
+		0,0,0,0,1,1,0,0,
+		0,0,0,0,1,1,0,0,
+		0,0,0,0,1,1,0,0,
+		1,1,1,1,1,1,0,0,
+		1,1,1,1,1,1,0,0,
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+	],
+	borderM: [
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+		0,0,0,0,0,0,0,0,
+	],
+
+	dialogStyles: {
+	// You can define alternate Dialog Styles here, which can be switched to in-game from dialog.
+	// These can be switched between using the (Style "styleName") or (ApplyStyle "styleName") commands.
+	// These Dialog Styles are meant as examples. Feel free to edit, rename, or remove them.
+		custom: {
+		// Copy any hackOptions from above into this section, and modify them, to create a new Style.
+			
+		},
+		vanilla: {
+		// An example style, which emulates the original Bitsy textbox.
+			verticalPosition: "shift",
+			horizontalPosition: "center",
+			textboxWidth: 104,
+			textboxMarginX: 12,
+			textboxMarginY: 12,
+			textMinLines: 2,
+			textMaxLines: 2,
+			textPaddingX: 8,
+			textPaddingY: 10,
+			borderWidth: 0,
+			borderHeight: 0,
+			arrowScale: 4,
+			arrowInsetX: 4,
+			arrowInsetY: 1,
+			arrowWidth: 5,
+			arrowHeight: 3,
+			arrowSprite: [
+				1,1,1,1,1,
+				0,1,1,1,0,
+				0,0,1,0,0,
+			],
+		},
+		centered: {
+		// An example style, that centers the textbox as with Starting or Ending text.
+			verticalPosition: "center",
+			horizontalPosition: "center",
+		},
+		vertical: {
+		// An example style, that positions the textbox vertically, on the left or right side.
+			verticalPosition: "center",
+			horizontalPosition: "shift",
+			textboxWidth: 48,
+			textMinLines: 16,
+			textMaxLines: 16,
+		},
+		corner: {
+		// An example style, which positions a resizing textbox in the corner opposite the player.
+			verticalPosition: "shift",
+			horizontalPosition: "shift",
+			textboxWidth: 64,
+			textMinLines: 1,
+			textMaxLines: 8,
+		},
+		inverted: {
+		// An example style, which inverts the normal textbox colors
+			textboxColor: [255,255,255,255],
+			textColor: [0,0,0,255],
+			borderColor: [128,128,128,255],
+			borderMidColor: [204,204,204,255],
+			borderBGColor: [255,255,255,255],
+			arrowColor: [0,0,0,255],
+			arrowBGColor: [255,255,255,255],
+		},
+		smallBorder: {
+		// An example style, which uses a smaller border with a blue background.
+			borderWidth: 4,
+			borderHeight: 4,
+			textPaddingX: 4,
+			textPaddingY: 4,
+			borderColor: [255,255,255,255],
+			borderBGColor: [51,153,204,255],
+			arrowBGColor: [51,153,204,255],
+			borderUL: [
+				0,0,0,0,
+				0,1,1,1,
+				0,1,1,0,
+				0,1,0,1,
+			],
+			borderU: [
+				0,0,0,0,
+				1,1,1,1,
+				0,0,0,0,
+				0,0,0,0,
+			],
+			borderUR: [
+				0,0,0,0,
+				1,1,1,0,
+				0,0,1,0,
+				0,1,1,0,
+			],
+			borderL: [
+				0,1,0,0,
+				0,1,0,0,
+				0,1,0,0,
+				0,1,0,0,
+			],
+			borderR: [
+				1,1,1,0,
+				1,1,1,0,
+				1,1,1,0,
+				1,1,1,0,
+			],
+			borderDL: [
+				0,1,0,0,
+				0,1,0,1,
+				0,1,1,1,
+				0,0,0,0,
+			],
+			borderD: [
+				1,1,1,1,
+				1,1,1,1,
+				1,1,1,1,
+				0,0,0,0,
+			],
+			borderDR: [
+				0,1,1,0,
+				1,0,1,0,
+				1,1,1,0,
+				0,0,0,0,
+			],
+			borderM: [
+				0,0,0,0,
+				0,0,0,0,
+				0,0,0,0,
+				0,0,0,0,
+			],
+		},
+	},
+};
+
+// =============================================================
+// | HACK SCRIPT INJECTS |/////////////////////////////////////|
+// =============================================================
+// Replaces initial textbox parameters, based on currently active style (or defaults).
+// Makes textboxInfo available at the window level
+// Recalculates textbox parameters, even values no longer used with hack, for compatability.
+var textboxInfoReplace = `var textboxInfo = {
+	img : null,
+	width : textboxStyler.activeStyle.textboxWidth,
+	height : textboxStyler.activeStyle.textPaddingY + textboxStyler.activeStyle.borderHeight - 2 + (2 * textboxStyler.activeStyle.textMinLines),
+	top : textboxStyler.activeStyle.textboxMarginY,
+	left : textboxStyler.activeStyle.textboxMarginX,
+	bottom : textboxStyler.activeStyle.textboxMarginY,
+	font_scale : textboxStyler.activeStyle.textScale/4,
+	padding_vert : textboxStyler.activeStyle.textPaddingY,
+	padding_horz : textboxStyler.activeStyle.textPaddingX,
+	arrow_height : textboxStyler.activeStyle.textPaddingY + textboxStyler.activeStyle.borderHeight - 4,
+};
+window.textboxInfo = textboxInfo;`;
+inject(/var textboxInfo = [^]*?};/, textboxInfoReplace);
+
+// Replaces ClearTextbox function to include border-drawing scripts
+var clearTextboxReplace = `this.ClearTextbox = function() {
+	if(context == null) return;
+
+	//create new image none exists
+	if(textboxInfo.img == null)
+		textboxInfo.img = context.createImageData(textboxInfo.width*scale, textboxInfo.height*scale);
+
+	// Draw Textbox Background based on BGColor (indices are R,G,B, and A)
+	for (var i=0;i<textboxInfo.img.data.length;i+=4)
+	{
+		textboxInfo.img.data[i+0]=textboxStyler.activeStyle.textboxColor[0];
+		textboxInfo.img.data[i+1]=textboxStyler.activeStyle.textboxColor[1];
+		textboxInfo.img.data[i+2]=textboxStyler.activeStyle.textboxColor[2];
+		textboxInfo.img.data[i+3]=textboxStyler.activeStyle.textboxColor[3];
+	}
+
+	textboxStyler.drawBorder();
+};`
+inject(/this.ClearTextbox = [^]*?};/, clearTextboxReplace);
+
+// Replaces Draw Textbox function, with function that supports vertical and horizontal shifting
+var drawTextboxReplace = `this.DrawTextbox = function() {
+	if(context == null) return;
+
+	// Textbox defaults to center-aligned
+	var textboxXPosition = ((width/2)-(textboxInfo.width/2))*scale;
+	var textboxYPosition = ((height/2)-(textboxInfo.height/2))*scale;
+
+	if (isCentered) {
+		context.putImageData(textboxInfo.img, textboxXPosition, textboxYPosition);
+	}
+	else {
+		if (textboxStyler.activeStyle.verticalPosition.toLowerCase() == "shift") {
+			if (player().y < mapsize/2) {
+				//player on bottom half, so draw on top
+				textboxYPosition = ((height-textboxInfo.top-textboxInfo.height)*scale);
+			}
+			else {
+				textboxYPosition = textboxInfo.top*scale;
+			}
+		}
+		else if (textboxStyler.activeStyle.verticalPosition.toLowerCase() == "top") {
+			textboxYPosition = textboxInfo.top*scale;
+		}
+		else if (textboxStyler.activeStyle.verticalPosition.toLowerCase() == "bottom") {
+			textboxYPosition = ((height-textboxInfo.top-textboxInfo.height)*scale);
+		}
+
+		if (textboxStyler.activeStyle.horizontalPosition.toLowerCase() == "shift") {
+			if (player().x < mapsize/2) {
+				// player on left half, so draw on right
+				textboxXPosition = ((width-textboxInfo.left-textboxInfo.width)*scale);
+			}
+			else {
+				textboxXPosition = textboxInfo.left*scale;
+			}
+		}
+		else if (textboxStyler.activeStyle.horizontalPosition.toLowerCase() == "right") {
+			textboxXPosition = ((width-textboxInfo.left-textboxInfo.width)*scale);
+		}
+		else if (textboxStyler.activeStyle.horizontalPosition.toLowerCase() == "left") {
+			textboxXPosition = textboxInfo.left*scale;
+		}
+
+		// Draw the Textbox
+		context.putImageData(textboxInfo.img, textboxXPosition, textboxYPosition);
+	}
+};`;
+inject(/this.DrawTextbox = [^]*?};/, drawTextboxReplace);
+
+// Replace DrawNextArrow function, to support custom sprites, colors, and arrow repositioning
+var drawNextArrowReplace = `this.DrawNextArrow = function() {
+	// Arrow sprite is center-bottom by default
+	var top = ((4/textboxStyler.activeStyle.arrowScale)*textboxInfo.height - textboxStyler.activeStyle.arrowHeight - textboxStyler.activeStyle.arrowInsetY) *  textboxStyler.activeStyle.arrowScale;
+	var left = ((4/textboxStyler.activeStyle.textboxArrowScale)*textboxInfo.width - textboxStyler.activeStyle.arrowXSize) * textboxStyler.activeStyle.textboxArrowScale*0.5;
+
+	// Reposition arrow based on arrowAlign and RTL settings (flipped for RTL Languages)
+	if (textboxStyler.activeStyle.arrowAlign.toLowerCase() == "left") {
+		if (textDirection === TextDirection.RightToLeft) {
+			left = ((4/textboxStyler.activeStyle.arrowScale)*textboxInfo.width - textboxStyler.activeStyle.arrowWidth - textboxStyler.activeStyle.arrowInsetX) *  textboxStyler.activeStyle.arrowScale;
+		}
+		else {
+			left = (textboxStyler.activeStyle.arrowXPadding) * textboxStyler.activeStyle.textboxArrowScale;
+		}
+	}
+	else if (textboxStyler.activeStyle.arrowAlign.toLowerCase() == "right") {
+		if (textDirection === TextDirection.RightToLeft) {
+			left = (arrowXPadding) * textboxArrowScale;
+		}
+		else {
+			left = ((4/textboxStyler.activeStyle.arrowScale)*textboxInfo.width - textboxStyler.activeStyle.arrowWidth - textboxStyler.activeStyle.arrowInsetX) *  textboxStyler.activeStyle.arrowScale;
+		}
+	}
+	
+	// Draw arrow sprite pixels on textbox
+	for (var y = 0; y < textboxStyler.activeStyle.arrowHeight; y++) {
+		for (var x = 0; x < textboxStyler.activeStyle.arrowWidth; x++) {
+			var i = (y * textboxStyler.activeStyle.arrowWidth) + x;
+
+			//scaling hooplah
+			for (var sy = 0; sy < textboxStyler.activeStyle.arrowScale; sy++) {
+				for (var sx = 0; sx < textboxStyler.activeStyle.arrowScale; sx++) {
+					var pxl = 4 * ( ((top+(y*textboxStyler.activeStyle.arrowScale)+sy) * (textboxInfo.width*4)) + (left+(x*textboxStyler.activeStyle.arrowScale)+sx) );
+					// Draws arrow's pixels in Arrow Color
+					if (textboxStyler.activeStyle.arrowSprite[i] == 1) {
+						textboxInfo.img.data[pxl+0] = textboxStyler.activeStyle.arrowColor[0];
+						textboxInfo.img.data[pxl+1] = textboxStyler.activeStyle.arrowColor[1];
+						textboxInfo.img.data[pxl+2] = textboxStyler.activeStyle.arrowColor[2];
+						textboxInfo.img.data[pxl+3] = textboxStyler.activeStyle.arrowColor[3];
+					}
+					// Draws arrow's bg pixels using Arrow BG Color
+					else {
+						textboxInfo.img.data[pxl+0] = textboxStyler.activeStyle.arrowBGColor[0];
+						textboxInfo.img.data[pxl+1] = textboxStyler.activeStyle.arrowBGColor[1];
+						textboxInfo.img.data[pxl+2] = textboxStyler.activeStyle.arrowBGColor[2];
+						textboxInfo.img.data[pxl+3] = textboxStyler.activeStyle.arrowBGColor[3];
+					}
+				}
+			}
+		}
+	}
+};`;
+inject(/this.DrawNextArrow = [^]*?};/, drawNextArrowReplace);
+
+// Inject to support custom text scaling
+inject(/var text_scale = .+?;/, 'var text_scale = textboxStyler.activeStyle.textScale;');
+
+// Injects to support text padding within the textbox
+var topTextPaddingReplace = `var top = (2 * textboxStyler.activeStyle.textPaddingY) + (textboxStyler.activeStyle.borderHeight * 2) + (row * 2 * scale) + (row * font.getHeight() * textboxStyler.activeStyle.textScale) + Math.floor( char.offset.y );`;
+var leftTextPaddingReplace = `var left = (2* textboxStyler.activeStyle.textPaddingX) + (textboxStyler.activeStyle.borderWidth * 2) + (leftPos * textboxStyler.activeStyle.textScale) + Math.floor( char.offset.x );`;
+inject(/var top = \(4 \* scale\) \+ \(row \* 2 \* scale\) .+?\);/, topTextPaddingReplace);
+inject(/var left = \(4 \* scale\) \+ \(leftPos \* text_scale\) .+?\);/, leftTextPaddingReplace);
+
+// Inject to support custom text speeds
+inject(/var nextCharMaxTime = .+?;/, 'var nextCharMaxTime = textboxStyler.activeStyle.textSpeed;');
+
+// Inject to support custom default text color
+inject(/this.color = .+?};/, 'this.color = { r:textboxStyler.activeStyle.textColor[0], g:textboxStyler.activeStyle.textColor[1], b:textboxStyler.activeStyle.textColor[2], a:textboxStyler.activeStyle.textColor[3] };');
+
+// Inject to support dynamic textbox resizing. Attach to window to make it accessible from hack.
+inject(/var pixelsPerRow = .+?;/, 'window.pixelsPerRow = (textboxStyler.activeStyle.textboxWidth*(4/textboxStyler.activeStyle.textScale)) - (textboxStyler.activeStyle.borderWidth*(4/textboxStyler.activeStyle.textScale)) - (textboxStyler.activeStyle.textPaddingX*(4/textboxStyler.activeStyle.textScale));');
+//var pixelsPerRow = (textboxWidth*2) - (borderWidth*2) - (textPaddingX*2); // hard-coded fun times!!! 192
+
+// Store font height at parent level when calculated.
+var fontSizeInject = `else if (args[0] == "SIZE") {
+	width = parseInt(args[1]);
+	height = parseInt(args[2]);
+	window.fontHeight = height;
+	console.log(fontHeight);
+}`
+inject(/else if \(args\[0\] == "SIZE"\) {[^]*?}/, fontSizeInject);
+console.log(fontSizeInject);
+// =============================================================
+// | RE-IMPLIMENTED LONG DIALOG HACK INJECTS |/////////////////|
+// =============================================================
+// Modified from Sean leBlanc's Long Dialog hack, to include textbox borders and padding
+// Needed to recalculate textbox height, based on current style parameters.
+// Added textMinLines and textMaxLines to hackOptions parameters, to include in style swapping
+
+// override textbox height (and recalculate textboxWidth)
+inject(/textboxInfo\.height = .+;/, `Object.defineProperty(textboxInfo, 'height', {
+	get() { return textboxStyler.activeStyle.textPaddingY + textboxStyler.activeStyle.borderHeight - 2 + ((2 + relativeFontHeight()) * Math.max(textboxStyler.activeStyle.textMinLines, dialogBuffer.CurPage().indexOf(dialogBuffer.CurRow())+Math.sign(dialogBuffer.CurCharCount()))); }
+})`);
+
+// prevent textbox from caching
+inject(/(if\(textboxInfo\.img == null\))/, '// $1');
+
+// rewrite hard-coded row limit
+inject(/(else if \(curRowIndex )== 0/g, '$1 < textboxStyler.activeStyle.textMaxLines - 1');
+inject(/(if\( lastPage\.length) <= 1( \) {)/, '$1 < textboxStyler.activeStyle.textMaxLines $2');
+
+// =============================================================
+// | HACK FUNCTIONS |//////////////////////////////////////////|
+// =============================================================
+
+// Make them accessible at a higher scope, so Dialog functions can see them.
+window.textboxStyler = {
+	defaultStyle: {
+		verticalPosition: hackOptions.verticalPosition,
+		horizontalPosition: hackOptions.horizontalPosition,
+		textboxColor: hackOptions.textboxColor,
+		textboxWidth: hackOptions.textboxWidth,
+		textboxMarginX: hackOptions.textboxMarginX,
+		textboxMarginY: hackOptions.textboxMarginY,
+		textColor: hackOptions.textColor,
+		textMinLines: hackOptions.textMinLines,
+		textMaxLines: hackOptions.textMaxLines,
+		textScale: hackOptions.textScale,
+		textSpeed: hackOptions.textSpeed,
+		textPaddingX: hackOptions.textPaddingX,
+		textPaddingY: hackOptions.textPaddingY,
+		borderColor: hackOptions.borderColor,
+		borderBGColor: hackOptions.borderBGColor,
+		borderMidColor: hackOptions.borderMidColor,
+		borderWidth: hackOptions.borderWidth,
+		borderHeight: hackOptions.borderHeight,
+		borderScale: hackOptions.borderScale,
+		arrowColor: hackOptions.arrowColor,
+		arrowBGColor: hackOptions.arrowBGColor,
+		arrowScale: hackOptions.arrowScale,
+		arrowAlign: hackOptions.arrowAlign,
+		arrowInsetX: hackOptions.arrowInsetX,
+		arrowInsetY: hackOptions.arrowInsetY,
+		arrowWidth: hackOptions.arrowWidth,
+		arrowHeight: hackOptions.arrowHeight,
+		arrowSprite: hackOptions.arrowSprite,
+		borderUL: hackOptions.borderUL,
+		borderU: hackOptions.borderU,
+		borderUR: hackOptions.borderUR,
+		borderL: hackOptions.borderL,
+		borderR: hackOptions.borderR,
+		borderDL: hackOptions.borderDL,
+		borderD: hackOptions.borderD,
+		borderDR: hackOptions.borderDR,
+		borderM: hackOptions.borderM,
+	},
+
+	activeStyle: {
+		verticalPosition: hackOptions.verticalPosition,
+		horizontalPosition: hackOptions.horizontalPosition,
+		textboxColor: hackOptions.textboxColor,
+		textboxWidth: hackOptions.textboxWidth,
+		textboxMarginX: hackOptions.textboxMarginX,
+		textboxMarginY: hackOptions.textboxMarginY,
+		textColor: hackOptions.textColor,
+		textMinLines: hackOptions.textMinLines,
+		textMaxLines: hackOptions.textMaxLines,
+		textScale: hackOptions.textScale,
+		textSpeed: hackOptions.textSpeed,
+		textPaddingX: hackOptions.textPaddingX,
+		textPaddingY: hackOptions.textPaddingY,
+		borderColor: hackOptions.borderColor,
+		borderBGColor: hackOptions.borderBGColor,
+		borderMidColor: hackOptions.borderMidColor,
+		borderWidth: hackOptions.borderWidth,
+		borderHeight: hackOptions.borderHeight,
+		borderScale: hackOptions.borderScale,
+		arrowColor: hackOptions.arrowColor,
+		arrowBGColor: hackOptions.arrowBGColor,
+		arrowScale: hackOptions.arrowScale,
+		arrowAlign: hackOptions.arrowAlign,
+		arrowInsetX: hackOptions.arrowInsetX,
+		arrowInsetY: hackOptions.arrowInsetY,
+		arrowWidth: hackOptions.arrowWidth,
+		arrowHeight: hackOptions.arrowHeight,
+		arrowSprite: hackOptions.arrowSprite,
+		borderUL: hackOptions.borderUL,
+		borderU: hackOptions.borderU,
+		borderUR: hackOptions.borderUR,
+		borderL: hackOptions.borderL,
+		borderR: hackOptions.borderR,
+		borderDL: hackOptions.borderDL,
+		borderD: hackOptions.borderD,
+		borderDR: hackOptions.borderDR,
+		borderM: hackOptions.borderM,
+	},
+
+	styles: hackOptions.dialogStyles,
+
+	// Sets activeStyle elements to the new style if defined, or to defaultStyle's elements if not.
+	style: function (newStyle) {
+		console.log ("SETTING TEXTBOX STYLE TO: " + newStyle);
+		// If newStyle doesn't exist, resets to default
+		if (newStyle == undefined || textboxStyler.styles[newStyle] == undefined) {
+			textboxStyler.resetStyle();
+			console.log ("UNDEFINED STYLE. RESETTING TO DEFAULT.");
+			return false;
+		}
+		textboxStyler.activeStyle = Object.assign({}, textboxStyler.defaultStyle, textboxStyler.styles[newStyle]);
+		/*
+		Object.keys(textboxStyler.activeStyle).forEach(function(prop) {
+			if (textboxStyler.styles[newStyle].hasOwnProperty(prop)) {
+				textboxStyler.activeStyle[prop] = textboxStyler.styles[newStyle][prop];
+			}
+			else {
+				textboxStyler.activeStyle[prop] = textboxStyler.defaultStyle[prop];
+			}
+		});
+		*/
+		textboxStyler.updateTextbox(); // Updates values used for rendering text.
+	},
+	// Applies defined style parameters to the existing style, without changing anything else.
+	setStyle: function (newStyle) {
+		console.log ("APPLYING STYLE " + newStyle + " TO EXISTING TEXTBOX STYLE");
+		// If newStyle doesn't exist, does nothing.
+		if (textboxStyler.styles[newStyle] == undefined) {
+			console.log ("UNDEFINED STYLE.");
+			return false;
+		}
+		textboxStyler.activeStyle = Object.assign({}, textboxStyler.activeStyle, textboxStyler.styles[newStyle]);
+		/*
+		Object.keys(textboxStyler.activeStyle).forEach(function(prop) {
+			if (textboxStyler.styles[newStyle].hasOwnProperty(prop))
+			{
+				textboxStyler.activeStyle[prop] = textboxStyler.styles[newStyle][prop];
+			}
+		});
+		*/
+		textboxStyler.updateTextbox();
+	},
+	// Manually sets a specific property of the active style.
+	setProperty: function (property, value) {
+		value = "default";
+		console.log ("APPLYING STYLE PROPERTY: " + property + ", " + value);
+		if (textboxStyler.activeStyle.hasOwnProperty(property)) {
+			if (value == undefined || value == "default") {
+				console.log ("UNDEFINED PROPERTY. SETTING TO DEFAULT.");
+				//textboxStyle.activeStyle[property] = textboxStyle.defaultStyle[property];
+				textboxStyler.activeStyle[property] = Object.assign({}, textboxStyler.defaultStyle)[property];
+			}
+			else {
+				textboxStyler.activeStyle[property] = value;
+			}
+		}
+
+		textboxStyler.updateTextbox();
+	},
+	// Resets Active Textbox Style to Default Style
+	resetStyle: function () {
+		console.log ("RESETTING TO DEFAULT TEXTBOX STYLE");
+		//textboxStyler.activeStyle = textboxStyler.defaultStyle;
+		textboxStyler.activeStyle = Object.assign({}, textboxStyler.defaultStyle);
+
+		textboxStyler.updateTextbox();
+	},
+	// Resets a Textbox Style Property to it's Default value
+	resetProperty: function (property) {
+		console.log ("RESETTING STYLE PROPERTY TO DEFAULT: " + property);
+		if (textboxStyler.activeStyle.hasOwnProperty(property)) {
+			// textboxStyle.activeStyle[property] = textboxStyle.defaultStyle[property]; //Don't do it like this. Clone object instead of passing ref.
+			textboxStyler.activeStyle[property] = Object.assign({}, textboxStyler.defaultStyle)[property];
+		}
+		else {
+			console.log ("UNDEFINED PROPERTY.");
+			return false;
+		}
+
+		textboxStyler.updateTextbox();
+	},
+	// A command to set or adjust the absolute position, width, and lines of a textbox.
+	textboxPosition: function (x, y, boxWidth, boxMinLines, boxMaxLines) {
+		var curX = textboxStyler.activeStyle.textboxMarginX;
+		var curY = textboxStyler.activeStyle.textboxMarginY;
+		var curWidth = textboxStyler.activeStyle.textboxWidth;
+		var curMinLines = textboxStyler.activeStyle.textboxMinLines;
+		var curMaxLines = textboxStyler.activeStyle.textboxMaxLines;
+
+		// X Position
+		if (x == undefined) {
+			x = curX;
+		}
+		else {
+			x = x.toString().trim();
+			if (x == "" ) { x = curX; }
+			else if (x.includes("+")) { x = curX + parseInt(x.substring(1)); }
+			else if (x.includes("-")) { x = curX - parseInt(x.substring(1)); }
+		}
+		if (x < -128 || x > 128) {
+			console.log("CLAMPING X POSITION. XPOS ("+x+") OUT OF BOUNDS. 0-128 EXPECTED.");
+			x = Math.max(0, Math.min(x, 128));
+		}
+		// Y Position
+		if (y == undefined) {
+			y = curY;
+		}
+		else {
+			y = y.toString().trim();
+			if (y == "" ) { y = curY; }
+			else if (y.includes("+")) { y = curY + parseInt(y.substring(1)); }
+			else if (y.includes("-")) { y = curY - parseInt(y.substring(1)); }
+		}
+		if (y < -128 || y > 128) {
+			console.log("CLAMPING Y POSITION. YPOS ("+y+") OUT OF BOUNDS. 0-128 EXPECTED.");
+			y = Math.max(0, Math.min(y, 128));
+		}
+		// Width
+		if (boxWidth == undefined) {
+			boxWidth = curWidth;
+		}
+		else {
+			boxWidth = boxWidth.toString().trim();
+			if (boxWidth == "" ) { boxWidth = curWidth; }
+			else if (boxWidth.includes("+")) { boxWidth = curWidth + parseInt(boxWidth.substring(1)); }
+			else if (boxWidth.includes("-")) { boxWidth = curWidth - parseInt(boxWidth.substring(1)); }
+		}
+		if (boxWidth < 0 || boxWidth > 128) {
+			console.log("CLAMPING WIDTH ("+(boxWidth)+"). 0-128 EXPECTED.");
+			boxWidth = Math.max(0, Math.min(boxWidth, 128));
+		}
+		// Minimum Lines
+		if (boxMinLines == undefined) {
+			boxMinLines = curMinLines;
+		}
+		else {
+			boxMinLines = boxMinLines.toString().trim();
+			if (boxMinLines == "" ) { boxMinLines = curMinLines; }
+			else if (boxMinLines.includes("+")) { boxMinLines = curMinLines + parseInt(boxMinLines.substring(1)); }
+			else if (boxMinLines.includes("-")) { boxMinLines = curMinLines - parseInt(boxMinLines.substring(1)); }
+		}
+		if (boxMinLines < 0 || boxMinLines > 128) {
+			console.log("CLAMPING TEXT MIN LINES ("+(boxMinLines)+"). 0-128 EXPECTED.");
+			boxMinLines = Math.max(0, Math.min(boxMinLines, 128));
+		}
+		// Maximum Lines
+		if (boxMaxLines == undefined) {
+			boxMaxLines = curMaxLines;
+		}
+		else {
+			boxMaxLines = boxMaxLines.toString().trim();
+			if (boxMaxLines == "" ) { boxMaxLines = boxMaxLines; }
+			else if (boxMaxLines.includes("+")) { boxMaxLines = boxMaxLines + parseInt(boxMaxLines.substring(1)); }
+			else if (boxMaxLines.includes("-")) { boxMaxLines = boxMaxLines - parseInt(boxMaxLines.substring(1)); }
+		}
+		if (boxMaxLines < 0 || boxMaxLines > 128) {
+			console.log("CLAMPING TEXT MAX LINES ("+(boxMaxLines)+"). 0-128 EXPECTED.");
+			boxMaxLines = Math.max(0, Math.min(boxMaxLines, 128));
+		}
+
+		textboxStyler.activeStyle.textboxWidth = boxWidth;
+		textboxStyler.activeStyle.textboxMinLines = boxMinLines;
+		textboxStyler.activeStyle.textboxMaxLines = boxMaxLines;
+		textboxStyler.activeStyle.textboxMarginY = y;
+		textboxStyler.activeStyle.textboxMarginX = x;
+		textboxStyler.activeStyle.verticalPosition = "top";
+		textboxStyler.activeStyle.horizontalPosition = "left";
+
+		textboxStyler.updateTextbox();
+	},
+
+	// First draft of position. Kept here for future versions.
+	textboxCornersWIP: function (x1, y1, x2, y2) {
+		// Trim and sanitize X and Y Positions, and set to current position if omitted.
+		var curX1 = textboxStyler.activeStyle.textboxMarginX;
+		var curX2 = curX1 + textboxStyler.activeStyle.textboxWidth;
+		var curY1 = textboxStyler.activeStyle.textboxMarginY;
+		var curY2 = curY1 + (textboxStyler.activeStyle.textPaddingY + textboxStyler.activeStyle.borderHeight - 2 + (2 * textboxStyler.activeStyle.textMinLines));
+
+		if (x1 == undefined) {
+			x1 = curX1;
+		}
+		else {
+			x1 = x1.toString().trim();
+			if (x1 == "" ) { x1 = curX1; }
+			else if (x1.includes("+")) { x1 = curX1 + parseInt(x1.substring(1)); }
+			else if (x1.includes("-")) { x1 = curX1 - parseInt(x1.substring(1)); }
+		}
+		if (x1 < 0 || x1 > 128) {
+			console.log("CLAMPING X1 POSITION. XPOS ("+x1+") OUT OF BOUNDS. 0-128 EXPECTED.");
+			x1 = Math.max(0, Math.min(x1, 128));
+		}
+		// X2
+		if (x2 == undefined) {
+			x2 = curX2;
+		}
+		else {
+			x2 = x2.toString().trim();
+			if (x2 == "" ) { x2 = curX2; }
+			else if (x2.includes("+")) { x2 = curX2 + parseInt(x2.substring(1)); }
+			else if (x2.includes("-")) { x2 = curX2 - parseInt(x2.substring(1)); }
+		}
+		if (x2 < 0 || x2 > 128) {
+			console.log("CLAMPING X2 POSITION. xPos ("+x2+") OUT OF BOUNDS. 0-128 EXPECTED.");
+			x2 = Math.max(0, Math.min(x2, 128));
+		}
+		// Y1
+		if (y1 == undefined) {
+			y1 = curY1;
+		}
+		else {
+			y1 = y1.toString().trim();
+			if (y1 == "" ) { y1 = curY1; }
+			else if (y1.includes("+")) { y1 = curY1 + parseInt(y1.substring(1)); }
+			else if (y1.includes("-")) { y1 = curY1 - parseInt(y1.substring(1)); }
+		}
+		if (y1 < 0 || y1 > 128) {
+			console.log("CLAMPING Y1 POSITION. XPOS ("+y1+") OUT OF BOUNDS. 0-128 EXPECTED.");
+			y1 = Math.max(0, Math.min(y1, 128));
+		}
+		// Y2
+		if (y2 == undefined) {
+			y2 = curY2;
+		}
+		else {
+			y2 = y2.toString().trim();
+			if (y2 == "" ) { y2 = curY2; }
+			else if (y2.includes("+")) { y2 = curY2 + parseInt(y2.substring(1)); }
+			else if (y2.includes("-")) { y2 = curY2 - parseInt(y2.substring(1)); }
+		}
+		if (y2 < 0 || y2 > 128) {
+			console.log("CLAMPING Y2 POSITION. xPos ("+y2+") OUT OF BOUNDS. 0-128 EXPECTED.");
+			y2 = Math.max(0, Math.min(y2, 128));
+		}
+
+		console.log ("SETTING TEXTBOX CORNERS TO ("+x1+","+y1+") and ("+x2+","+y2+")");
+		var topPos = Math.min(y1, y2);
+		var leftPos = Math.min(x1, x2);
+		var bottomPos = Math.max(y1, y2);
+		var rightPos = Math.max(x1, x2);
+		var width = rightPos-leftPos;
+		var height = bottomPos-topPos;
+		var lineCount = Math.floor(height/8);
+
+		textboxStyler.activeStyle.textboxWidth = width;
+		textboxStyler.activeStyle.textMinLines = Math.max(1,lineCount);
+		textboxStyler.activeStyle.textMaxLines = Math.max(1,lineCount);
+		textboxStyler.activeStyle.textPaddingY = (height - (textboxStyler.activeStyle.textMinLines*8)) / 2;
+		textboxStyler.activeStyle.textboxMarginY = topPos;
+		textboxStyler.activeStyle.textboxMarginX = leftPos;
+		textboxStyler.activeStyle.verticalPosition = "top";
+		textboxStyler.activeStyle.horizontalPosition = "left";
+
+		textboxStyler.updateTextbox();
+	},
+	// Updates parameters of the textbox based on style settings.
+	// TODO: see if you can re-render existing textbox content in new style?
+	updateTextbox: function () {
+		textboxInfo.width = textboxStyler.activeStyle.textboxWidth;
+		//textboxInfo.height = textboxStyler.activeStyle.textPaddingY + textboxStyler.activeStyle.borderHeight - 2 + (2 * textboxStyler.activeStyle.textMinLines);
+		textboxInfo.top = textboxStyler.activeStyle.textboxMarginY;
+		textboxInfo.left = textboxStyler.activeStyle.textboxMarginX;
+		textboxInfo.bottom = textboxStyler.activeStyle.textboxMarginY;
+		textboxInfo.font_scale = textboxStyler.activeStyle.textScale/4;
+		textboxInfo.padding_vert = textboxStyler.activeStyle.textPaddingY;
+		textboxInfo.padding_horz = textboxStyler.activeStyle.textPaddingX;
+		textboxInfo.arrow_height = textboxStyler.activeStyle.textPaddingY + textboxStyler.activeStyle.borderHeight - 4;
+
+		pixelsPerRow = (textboxStyler.activeStyle.textboxWidth*2) - (textboxStyler.activeStyle.borderWidth*2) - (textboxStyler.activeStyle.textPaddingX*2);
+
+		textboxInfo.img = ctx.createImageData(textboxInfo.width*scale, textboxInfo.height*scale);
+	},
+	// Draw border to the background of the textbox image, before rendering text or arrows.
+	drawBorder: function () {
+		// console.log ("DRAWING TEXTBOX BORDER");
+		// Iterates through each pixel of the textbox, and determines if a border pixel should be drawn.
+		// Compares 1D array of textbox pixels to 1D arrays for each border sprite, to determine whether to draw a pixel.
+		for (var y = 0; y < (4/textboxStyler.activeStyle.borderScale)*textboxInfo.height; y++) {
+			for (var x = 0; x < (4/textboxStyler.activeStyle.borderScale)*textboxInfo.width; x++) {
+				// NOTE: borderXId and borderYId translate message box coordinates to border tile coordinates.
+				// Use modulo to translate textbox space into tiles, for drawing borders pixel-by-pixel.
+				// For bottom/right borders, border sprites should be anchored to the bottom/right instead.
+				// borderYId and borderXId get pixel coordinates anchored to the top or left
+				// borderDId and borderRId get pixel coordinates anchored to down or right (for right/bottom edges)
+				var borderYId = (y % textboxStyler.activeStyle.borderHeight);
+				var borderXId = (x % textboxStyler.activeStyle.borderWidth);
+				var borderDId = ((y+((4/textboxStyler.activeStyle.borderScale)*textboxInfo.height)) % textboxStyler.activeStyle.borderHeight);
+				var borderRId = ((x+((4/textboxStyler.activeStyle.borderScale)*textboxInfo.width)) % textboxStyler.activeStyle.borderWidth);
+				
+				// NOTE: There's a weird bug with odd vs even textbox heights. Here's a hacky fix for now.
+				// TODO: Handle decimal heights? Still bugs with those (may come up with bitsy's text scaling)
+				if (textboxInfo.height % textboxStyler.activeStyle.borderScale != 0) {
+					borderDId = ((y-4+((4/textboxStyler.activeStyle.borderScale)*textboxInfo.height)) % textboxStyler.activeStyle.borderHeight);
+				} 
+
+				// Calculates index in the 1D array of the border sprite.
+				var borderPxl = (borderYId*textboxStyler.activeStyle.borderWidth) + borderXId;
+				var bottomPxl = (borderDId*textboxStyler.activeStyle.borderWidth) + borderXId;
+				var rightPxl = (borderYId*textboxStyler.activeStyle.borderWidth) + borderRId;
+				var bottomRightPxl = (borderDId*textboxStyler.activeStyle.borderWidth) + borderRId;
+
+				// Determines if the current pixel is along one of the textbox's edges, or if it's in the center.
+				var borderTop = y < textboxStyler.activeStyle.borderHeight;
+				var borderBottom = y >= textboxInfo.height*(4/textboxStyler.activeStyle.borderScale)-textboxStyler.activeStyle.borderHeight;
+				var borderLeft = x < textboxStyler.activeStyle.borderWidth;
+				var borderRight = x >= textboxInfo.width*(4/textboxStyler.activeStyle.borderScale)-textboxStyler.activeStyle.borderWidth;
+
+				// Does this pixel is draw???
+				// 1= draw a border pixel, 0= No! Draw a border bg pixel instead
+				var borderDraw;
+
+				// Retrieve pixel data from appropriate sprite. Special handling for bottom/right borders!
+				if (borderBottom) {
+					// Bottom Left Corner
+					if (borderLeft) { borderDraw = textboxStyler.activeStyle.borderDL[bottomPxl]; }
+					// Bottom Right Corner
+					else if (borderRight) { borderDraw = textboxStyler.activeStyle.borderDR[bottomRightPxl]; }
+					// Bottom Middle Edge
+					else { borderDraw = textboxStyler.activeStyle.borderD[bottomPxl]; }
+				}
+				else if (borderTop) {
+					// Top Left Corner
+					if (borderLeft) { borderDraw = textboxStyler.activeStyle.borderUL[borderPxl]; }
+					// Top Right Corner
+					else if (borderRight) { borderDraw = textboxStyler.activeStyle.borderUR[rightPxl]; }
+					// Top Middle Edge
+					else { borderDraw = textboxStyler.activeStyle.borderU[borderPxl]; }
+				}
+				// Left Edge
+				else if (borderLeft) { borderDraw = textboxStyler.activeStyle.borderL[borderPxl]; }
+				// Right Edge
+				else if (borderRight) { borderDraw = textboxStyler.activeStyle.borderR[rightPxl]; }
+				// Middle
+				else { borderDraw = textboxStyler.activeStyle.borderM[borderPxl]; }
+
+				//scaling shenanigans (maps sprite scale pixels to bitsy/screen-scale pixels)
+				for (var sy = 0; sy < textboxStyler.activeStyle.borderScale; sy++) {
+					for (var sx = 0; sx < textboxStyler.activeStyle.borderScale; sx++) {
+						var pxl = 4 * ( (((textboxStyler.activeStyle.borderScale*y)+sy) * (4*textboxInfo.width)) + (textboxStyler.activeStyle.borderScale*x)+sx );
+
+						// If it's a border pixel, Retrieves RGBA values for the border, and draws it.
+						if (borderDraw) {
+							if (borderTop || borderBottom || borderLeft || borderRight) {
+								textboxInfo.img.data[pxl+0] = textboxStyler.activeStyle.borderColor[0];
+								textboxInfo.img.data[pxl+1] = textboxStyler.activeStyle.borderColor[1];
+								textboxInfo.img.data[pxl+2] = textboxStyler.activeStyle.borderColor[2];
+								textboxInfo.img.data[pxl+3] = textboxStyler.activeStyle.borderColor[3];
+							}
+							else {
+								textboxInfo.img.data[pxl+0] = textboxStyler.activeStyle.borderMidColor[0];
+								textboxInfo.img.data[pxl+1] = textboxStyler.activeStyle.borderMidColor[1];
+								textboxInfo.img.data[pxl+2] = textboxStyler.activeStyle.borderMidColor[2];
+								textboxInfo.img.data[pxl+3] = textboxStyler.activeStyle.borderMidColor[3];
+							}
+							//DEBUG COLORS. UNCOMMENT TO DRAW PIXELS BASED ON TEXTBOX COORDINATES, 0-255
+							/*textboxInfo.img.data[pxl+0] = 204-(x);
+							textboxInfo.img.data[pxl+1] = 204-(x+y);
+							textboxInfo.img.data[pxl+2] = 204-(y*2);
+							textboxInfo.img.data[pxl+3] = 255;
+							//DRAWS TOP-LEFT-ANCHORED GRID TILE COORDINATES IN GREY
+							if (y % borderHeight == 0 || x % borderWidth == 0) {
+								textboxInfo.img.data[pxl+0] = 128;
+								textboxInfo.img.data[pxl+1] = 128;
+								textboxInfo.img.data[pxl+2] = 128;
+								textboxInfo.img.data[pxl+3] = 255;
+							}*/
+						}
+						// If it's a border BG pixel, gets RGBA colors based on if it's on an edge or in middle.
+						else {
+							if (borderTop || borderBottom || borderLeft || borderRight) {
+								textboxInfo.img.data[pxl+0] = textboxStyler.activeStyle.borderBGColor[0];
+								textboxInfo.img.data[pxl+1] = textboxStyler.activeStyle.borderBGColor[1];
+								textboxInfo.img.data[pxl+2] = textboxStyler.activeStyle.borderBGColor[2];
+								textboxInfo.img.data[pxl+3] = textboxStyler.activeStyle.borderBGColor[3];
+							}
+							else {
+								textboxInfo.img.data[pxl+0] = textboxStyler.activeStyle.textboxColor[0];
+								textboxInfo.img.data[pxl+1] = textboxStyler.activeStyle.textboxColor[1];
+								textboxInfo.img.data[pxl+2] = textboxStyler.activeStyle.textboxColor[2];
+								textboxInfo.img.data[pxl+3] = textboxStyler.activeStyle.textboxColor[3];
+							}
+							//DEBUG COLORS. UNCOMMENT TO DRAW PIXELS BASED ON TEXTBOX COORDINATES, 0-255
+							/*textboxInfo.img.data[pxl+0] = (x)+102;
+							textboxInfo.img.data[pxl+1] = (x+y);
+							textboxInfo.img.data[pxl+2] = (y*2)+51;
+							textboxInfo.img.data[pxl+3] = 255;
+							//DRAWS TOP-LEFT-ANCHORED GRID COORDINATES IN GREY
+							if (y % borderHeight == 0 || x % borderWidth == 0) {
+								textboxInfo.img.data[pxl+0] = 76;
+								textboxInfo.img.data[pxl+1] = 76;
+								textboxInfo.img.data[pxl+2] = 76;
+								textboxInfo.img.data[pxl+3] = 255;
+							}*/
+						}
+					}
+				}
+			}
+		}
+	},
+};

--- a/src/textbox styler.js
+++ b/src/textbox styler.js
@@ -1,7 +1,7 @@
 /**
 📐
 @file textbox styler
-@summary 
+@summary customize the style and properties of the textbox
 @license MIT
 @version 1.0.0
 @requires Bitsy Version: 6.1


### PR DESCRIPTION
3 new complete, documented, and hopefully bug-free Bitsy Hacks, for the consideration of the esteemed management of the Bitsy Hack Repository.

- **Edit Room from Dialog:** patterned after existing "Edit from Dialog" hacks, this allows drawing, erasing, replacing, or copying tiles, items, and sprites within a Bitsy room. This can be done on active or inactive rooms. Edit operations can be done on a tile-by-tile basis, in a line/box drawn between two points, or affecting an entire room. Copying allows duplication of tile elements, and replacement allows for replacement of elements (including switching from one type of element to another, such as turning a Tile into an Item).
- **Palette Maps:** adds a 16x16 palette map to each room, allowing palettes to be assigned on a tile-by-tile basis. The Palette Map affects any graphic drawn at that location, causing it to draw using that palette instead of the room's default palette. Palette Maps can be drawn for a room in the Hack Options. Dialog tags for editing the default room palette, as well as the tile-by-tile Palette Map, are included. Also includes a tag that can be added to a Tile, Item, or Sprite's name, to cause them to always be drawn in a certain palette.
- **Textbox Styler:** Allows the visual customization of textbox elements, the addition of a customizable border and arrows, and textbox resizing and repositioning. Also adds various other parameters such as text speed, textbox color, font scale, toggles for whether the textbox repositions based on the player's vertical or horizontal position (or neither, centering it along that axis), and more. In addition to configuring a default textbox style, you can also create alternate style profiles in the Hack Options, which can be switched between via various dialog tags. Other dialog tags exist to revert changes, tweak individual parameters such as text speed, or to reposition the textbox at a fixed location and size.