### PR TITLE
fix multi-sprite avatar movement

### DIFF
--- a/dist/multi-sprite-avatar.js
+++ b/dist/multi-sprite-avatar.js
@@ -3,7 +3,7 @@
 @file multi-sprite avatar
 @summary make the player big
 @license MIT
-@version 2.1.7
+@version 2.1.8
 @author Sean S. LeBlanc
 
 @description
@@ -381,7 +381,7 @@ var repeats = [
 // prevent player from colliding with their own pieces
 function filterPieces(id) {
 	for (var i = 0; i < pieces.length; ++i) {
-		if (id === pieces[i].spr) {
+		if (id === pieces[i].spr || (bitsy.sprite[id] && bitsy.sprite[id].name === pieces[i].spr)) {
 			return null;
 		}
 	}

--- a/src/multi-sprite avatar.js
+++ b/src/multi-sprite avatar.js
@@ -167,7 +167,7 @@ var repeats = [
 // prevent player from colliding with their own pieces
 function filterPieces(id) {
 	for (var i = 0; i < pieces.length; ++i) {
-		if (id === pieces[i].spr) {
+		if (id === pieces[i].spr || (bitsy.sprite[id] && bitsy.sprite[id].name === pieces[i].spr)) {
 			return null;
 		}
 	}

--- a/src/multi-sprite avatar.js
+++ b/src/multi-sprite avatar.js
@@ -3,7 +3,7 @@
 @file multi-sprite avatar
 @summary make the player big
 @license MIT
-@version 2.1.7
+@version 2.1.8
 @author Sean S. LeBlanc
 
 @description


### PR DESCRIPTION
sprites in pieces list can be by id or by name, but filter was only being applied by id, so the avatar was able to collide with pieces of itself