### PR TITLE
Add note about background-size in backdrop hack

### DIFF
--- a/src/backdrops.js
+++ b/src/backdrops.js
@@ -15,6 +15,7 @@ Note: includes transparent background/sprites
 HOW TO USE:
 1. Copy-paste this script into a script tag after the bitsy source
 2. Edit hackOptions below as needed
+3. You may need to add `background-size: cover` to the #game CSS up above to get the backdrop to fit correctly in the game screen
 */
 import bitsy from 'bitsy';
 import { after, before } from './helpers/kitsy-script-toolkit';


### PR DESCRIPTION
I was using this hack and noticed that my bg images didn't stretch/shrink to fit the game screen. Adding `background-size: cover` to the CSS seemed to fix it!